### PR TITLE
[Feat / Design] 게임 방 목록 페이지 레이아웃 및 기능 구현

### DIFF
--- a/frontend/db.json
+++ b/frontend/db.json
@@ -105,20 +105,17 @@
     {
         "id": 1,
         "title": "World Tournament",
-        "currentParty": 2,
-        "totalParty": 4
+        "currentParty": 2
         },
         {
         "id": 2,
         "title": "Tournament 2024",
-        "currentParty": 1,
-        "totalParty": 4
+        "currentParty": 1
         },
         {
         "id": 3,
         "title": "Kitty's tournament",
-        "currentParty": 3,
-        "totalParty": 4
+        "currentParty": 3
     }
   ],
   "rumbleList" : [

--- a/frontend/db.json
+++ b/frontend/db.json
@@ -100,8 +100,7 @@
     "subinlee",
     "kitty",
     "puppy"
-  ]
-  },
+  ],
   "roomList" : [
     {
       "id": 1,

--- a/frontend/db.json
+++ b/frontend/db.json
@@ -141,7 +141,7 @@
     },
     {
       "id": 5,
-      "title": "Hyonicho's game",
+      "title": "Hyobicho's game",
       "currentParty": 1
     },
     {

--- a/frontend/db.json
+++ b/frontend/db.json
@@ -103,19 +103,39 @@
   ],
   "tournamentList" : [
     {
-        "id": 1,
-        "title": "World Tournament",
-        "currentParty": 2
-        },
-        {
-        "id": 2,
-        "title": "Tournament 2024",
-        "currentParty": 1
-        },
-        {
-        "id": 3,
-        "title": "Kitty's tournament",
-        "currentParty": 3
+      "id": 1,
+      "title": "World Tournament",
+      "currentParty": 2
+    },
+    {
+      "id": 2,
+      "title": "Tournament 2024",
+      "currentParty": 1
+    },
+    {
+      "id": 3,
+      "title": "Kitty's tournament",
+      "currentParty": 3
+    },
+    {
+      "id": 4,
+      "title": "Puppy's tournament",
+      "currentParty": 1
+    },
+    {
+      "id": 5,
+      "title": "Hyungjpa's tournament",
+      "currentParty": 1
+    },
+    {
+      "id": 6,
+      "title": "Wonjilee's tournament",
+      "currentParty": 1
+    },
+    {
+      "id": 7,
+      "title": "Subinlee's tournament",
+      "currentParty": 1
     }
   ],
   "rumbleList" : [
@@ -147,6 +167,11 @@
     {
       "id": 6,
       "title": "Puppy's game",
+      "currentParty": 1
+    },
+    {
+      "id": 7,
+      "title": "Kitty's game",
       "currentParty": 1
     }
   ]

--- a/frontend/db.json
+++ b/frontend/db.json
@@ -83,5 +83,70 @@
         "score": "1:4"
       }
     ]
-  }
+  },
+  "roomList" : [
+    {
+      "id": 1,
+      "title": "World Tournament",
+      "type": "tournament",
+      "currentParty": 2,
+      "totalParty": 4
+    },
+    {
+      "id": 2,
+      "title": "Let's play Pong!",
+      "type": "rumble",
+      "currentParty": 1,
+      "totalParty": 4
+    },
+    {
+      "id": 3,
+      "title": "Subinlee's game",
+      "type": "rumble",
+      "currentParty": 1,
+      "totalParty": 2
+    },
+    {
+      "id": 4,
+      "title": "Wonjilee's game",
+      "type": "rumble",
+      "currentParty": 1,
+      "totalParty": 2
+    },
+    {
+      "id": 5,
+      "title": "Tournament 2024",
+      "type": "tournament",
+      "currentParty": 1,
+      "totalParty": 4
+    },
+    {
+      "id": 6,
+      "title": "Hyungjpa's game",
+      "type": "rumble",
+      "currentParty": 3,
+      "totalParty": 4
+    },
+    {
+      "id": 7,
+      "title": "Hyonicho's game",
+      "type": "rumble",
+      "currentParty": 1,
+      "totalParty": 2
+    },
+    {
+      "id": 8,
+      "title": "Puppy's game",
+      "type": "rumble",
+      "currentParty": 1,
+      "totalParty": 2
+    },
+    {
+      "id": 9,
+      "title": "Kitty's tournament",
+      "type": "tournament",
+      "currentParty": 3,
+      "totalParty": 4
+    }
+  ]
 }

--- a/frontend/db.json
+++ b/frontend/db.json
@@ -101,69 +101,56 @@
     "kitty",
     "puppy"
   ],
-  "roomList" : [
+  "tournamentList" : [
+    {
+        "id": 1,
+        "title": "World Tournament",
+        "currentParty": 2,
+        "totalParty": 4
+        },
+        {
+        "id": 2,
+        "title": "Tournament 2024",
+        "currentParty": 1,
+        "totalParty": 4
+        },
+        {
+        "id": 3,
+        "title": "Kitty's tournament",
+        "currentParty": 3,
+        "totalParty": 4
+    }
+  ],
+  "rumbleList" : [
     {
       "id": 1,
-      "title": "World Tournament",
-      "type": "tournament",
-      "currentParty": 2,
-      "totalParty": 4
+      "title": "Let's play Pong!",
+      "currentParty": 1
     },
     {
       "id": 2,
-      "title": "Let's play Pong!",
-      "type": "rumble",
-      "currentParty": 1,
-      "totalParty": 4
+      "title": "Subinlee's game",
+      "currentParty": 1
     },
     {
       "id": 3,
-      "title": "Subinlee's game",
-      "type": "rumble",
-      "currentParty": 1,
-      "totalParty": 2
+      "title": "Wonjilee's game",
+      "currentParty": 1
     },
     {
       "id": 4,
-      "title": "Wonjilee's game",
-      "type": "rumble",
-      "currentParty": 1,
-      "totalParty": 2
+      "title": "Hyungjpa's game",
+      "currentParty": 1
     },
     {
       "id": 5,
-      "title": "Tournament 2024",
-      "type": "tournament",
-      "currentParty": 1,
-      "totalParty": 4
+      "title": "Hyonicho's game",
+      "currentParty": 1
     },
     {
       "id": 6,
-      "title": "Hyungjpa's game",
-      "type": "rumble",
-      "currentParty": 3,
-      "totalParty": 4
-    },
-    {
-      "id": 7,
-      "title": "Hyonicho's game",
-      "type": "rumble",
-      "currentParty": 1,
-      "totalParty": 2
-    },
-    {
-      "id": 8,
       "title": "Puppy's game",
-      "type": "rumble",
-      "currentParty": 1,
-      "totalParty": 2
-    },
-    {
-      "id": 9,
-      "title": "Kitty's tournament",
-      "type": "tournament",
-      "currentParty": 3,
-      "totalParty": 4
+      "currentParty": 1
     }
   ]
 }

--- a/frontend/src/pages/game/JoinRoom.js
+++ b/frontend/src/pages/game/JoinRoom.js
@@ -69,8 +69,8 @@ class JoinRoom extends PageComponent {
           ${reloadRoomBtn}
         </div>
         <nav class="nav nav-tabs">
-          <button class="btn btn-outline-light fs-1 active" id="rumbleTab" data-bs-toggle="tab" type="button">Rumble</button>
-          <button class="btn btn-outline-light fs-1" id="tournamentTab" data-bs-toggle="tab" type="button" >Tournament</button>
+          <button class="col btn btn-outline-light fs-1 active" id="rumbleTab" data-bs-toggle="tab" type="button">Rumble</button>
+          <button class="col btn btn-outline-light fs-1" id="tournamentTab" data-bs-toggle="tab" type="button" >Tournament</button>
         </nav>
         <div class="d-flex flex-column h-75 justify-content-center">
           <div id="joinRoomBody" class="tab-pane active d-flex flex-column flex-column overflow-auto h-100">

--- a/frontend/src/pages/game/JoinRoom.js
+++ b/frontend/src/pages/game/JoinRoom.js
@@ -24,7 +24,6 @@ class JoinRoom extends PageComponent {
           text: `[ ${room.title} ] (${room.currentParty}/${totalParty})`,
           path: '/game/waiting',
           classList: 'btn btn-no-outline-hover fs-11 btn-arrow',
-          disabled: false,
         }).outerHTML;
       })
       .join('');
@@ -38,20 +37,23 @@ class JoinRoom extends PageComponent {
       classList:
         'fs-2 position-absolute top-0 end-0 mt-2 me-2 btn-no-outline-hover',
     });
-
     return `
       <div class="container h-100 p-3 game-room-border">
         <div class="d-flex justify-content-center position-relative">
           <h1 class="display-1 text-center">[ Room List ]</h1>
           ${reloadRoomBtn}
         </div>
-        <div class="d-flex justify-content-center h-75 overflow-auto">
-          <div id="joinRoomBody" class="d-flex flex-column">
+        <nav class="nav nav-tabs">
+          <button class="btn btn-outline-light fs-1 active" id="rumble-tab" data-bs-toggle="tab" type="button">Rumble</button>
+          <button class="btn btn-outline-light fs-1" id="tournament-tab" data-bs-toggle="tab" type="button" >Tournament</button>
+        </nav>
+        <div class="d-flex justify-content-center overflow-auto" style="height: 70%;">
+          <div id="joinRoomBody" class="tab-pane active d-flex flex-column">
             ${RoomLinks}
           </div>
         </div>
         <div class="d-flex justify-content-center">
-          pagination
+          >> 1 / 3 <<
         </div>
       </div>
       `;
@@ -62,6 +64,19 @@ class JoinRoom extends PageComponent {
     const joinRoomBody = document.getElementById('joinRoomBody');
 
     reloadRoomBtn.addEventListener('click', async () => {
+      joinRoomBody.innerHTML = await this.getRoomList();
+    });
+
+    const rumbleTab = document.getElementById('rumble-tab');
+    const tournamentTab = document.getElementById('tournament-tab');
+
+    rumbleTab.addEventListener('click', async () => {
+      this.mode = 'rumble';
+      joinRoomBody.innerHTML = await this.getRoomList();
+    });
+
+    tournamentTab.addEventListener('click', async () => {
+      this.mode = 'tournament';
       joinRoomBody.innerHTML = await this.getRoomList();
     });
   }

--- a/frontend/src/pages/game/JoinRoom.js
+++ b/frontend/src/pages/game/JoinRoom.js
@@ -23,14 +23,17 @@ class JoinRoom extends PageComponent {
             `/tournamentList?_page=${this.currPage}&_limit=${this.size}`
           );
 
-    const totalParty = this.mode === 'rumble' ? 2 : 4;
     this.totalPage = 2; // TODO: totalPage 받아오기
     this.setPagination();
 
     return roomList
       .map((room) => {
+        const text =
+          this.mode === 'rumble'
+            ? `[ ${room.title} ]`
+            : `[ ${room.title} ] (${room.currentParty}/4)`;
         return NavLink({
-          text: `[ ${room.title} ] (${room.currentParty}/${totalParty})`,
+          text,
           path: '/game/waiting',
           classList: 'btn btn-no-outline-hover fs-11 btn-arrow',
         }).outerHTML;

--- a/frontend/src/pages/game/JoinRoom.js
+++ b/frontend/src/pages/game/JoinRoom.js
@@ -1,7 +1,6 @@
 import PageComponent from '@component/PageComponent.js';
 import NavLink from '@component/navigation/NavLink';
 import Fetch from '@/utils/Fetch';
-// import BasicButton from '@component/button/BasicButton';
 
 class JoinRoom extends PageComponent {
   constructor() {
@@ -9,13 +8,10 @@ class JoinRoom extends PageComponent {
     this.setTitle('Join Room');
   }
 
-  async getRoomList() {
-    return Fetch.get('/roomList');
-  }
+  async getRoomLinks() {
+    const roomList = await Fetch.get('/roomList');
 
-  async render() {
-    const roomList = await this.getRoomList();
-    const RoomLinks = roomList
+    return roomList
       .map((room) => {
         return NavLink({
           text: `[ ${room.title} ] (${room.currentParty}/${room.totalParty})`,
@@ -25,6 +21,11 @@ class JoinRoom extends PageComponent {
         }).outerHTML;
       })
       .join('');
+  }
+
+  async render() {
+    const RoomLinks = await this.getRoomLinks();
+
     return `
       <div class="container h-100 p-3 game-room-border">
         <h1 class="display-1 text-center">[ Room List ]</h1>

--- a/frontend/src/pages/game/JoinRoom.js
+++ b/frontend/src/pages/game/JoinRoom.js
@@ -1,4 +1,7 @@
 import PageComponent from '@component/PageComponent.js';
+import NavLink from '@component/navigation/NavLink';
+import Fetch from '@/utils/Fetch';
+// import BasicButton from '@component/button/BasicButton';
 
 class JoinRoom extends PageComponent {
   constructor() {
@@ -6,12 +9,34 @@ class JoinRoom extends PageComponent {
     this.setTitle('Join Room');
   }
 
+  async getRoomList() {
+    return Fetch.get('/roomList');
+  }
+
   async render() {
+    const roomList = await this.getRoomList();
+    const RoomLinks = roomList
+      .map((room) => {
+        return NavLink({
+          text: `[ ${room.title} ] (${room.currentParty}/${room.totalParty})`,
+          path: '/game', // path: `/game/room/${room.id}`,
+          classList: 'btn btn-no-outline-hover fs-11 btn-arrow',
+          disabled: false,
+        }).outerHTML;
+      })
+      .join('');
     return `
-      <h1 class="display-1 text-center">[ Room List ]</h1>
-      <p>
-        this is a join room page
-      </p>
+      <div class="container h-100 p-3 game-room-border">
+        <h1 class="display-1 text-center">[ Room List ]</h1>
+        <div class="d-flex justify-content-center h-75 overflow-auto">
+          <div class="d-flex flex-column">
+            ${RoomLinks}
+          </div>
+        </div>
+        <div class="d-flex justify-content-center">
+          pagination
+        </div>
+      </div>
       `;
   }
 }

--- a/frontend/src/pages/game/JoinRoom.js
+++ b/frontend/src/pages/game/JoinRoom.js
@@ -15,7 +15,7 @@ class JoinRoom extends PageComponent {
       .map((room) => {
         return NavLink({
           text: `[ ${room.title} ] (${room.currentParty}/${room.totalParty})`,
-          path: '/game', // path: `/game/room/${room.id}`,
+          path: '/game/waiting',
           classList: 'btn btn-no-outline-hover fs-11 btn-arrow',
           disabled: false,
         }).outerHTML;

--- a/frontend/src/pages/game/JoinRoom.js
+++ b/frontend/src/pages/game/JoinRoom.js
@@ -25,6 +25,7 @@ class JoinRoom extends PageComponent {
 
     const totalParty = this.mode === 'rumble' ? 2 : 4;
     this.totalPage = 2; // TODO: totalPage 받아오기
+    this.setPagination();
 
     return roomList
       .map((room) => {
@@ -55,7 +56,7 @@ class JoinRoom extends PageComponent {
       id: 'nextBtn',
       text: '>',
       classList: 'fs-7 btn',
-      disabled: this.totalPage === 1,
+      disabled: this.totalPage === this.currPage,
     });
 
     return `
@@ -84,12 +85,35 @@ class JoinRoom extends PageComponent {
       `;
   }
 
+  setPagination() {
+    const prevBtn = document.getElementById('prevBtn');
+    const nextBtn = document.getElementById('nextBtn');
+    const currPage = document.getElementById('currPage');
+    const totalPage = document.getElementById('totalPage');
+
+    if (!prevBtn || !nextBtn || !currPage || !totalPage) return;
+
+    totalPage.innerHTML = this.totalPage;
+    currPage.innerHTML = this.currPage;
+    if (this.currPage === 1) {
+      prevBtn.setAttribute('disabled', 'true');
+    } else {
+      prevBtn.removeAttribute('disabled');
+    }
+    if (this.currPage === this.totalPage) {
+      nextBtn.setAttribute('disabled', 'true');
+    } else {
+      nextBtn.removeAttribute('disabled');
+    }
+  }
+
   async afterRender() {
     const joinRoomBody = document.getElementById('joinRoomBody');
 
     // 새로고침
     const reloadRoomBtn = document.getElementById('reloadRoomBtn');
     reloadRoomBtn.addEventListener('click', async () => {
+      this.currPage = 1;
       joinRoomBody.innerHTML = await this.getRoomList();
     });
 
@@ -98,41 +122,28 @@ class JoinRoom extends PageComponent {
     const tournamentTab = document.getElementById('tournamentTab');
     rumbleTab.addEventListener('click', async () => {
       this.mode = 'rumble';
+      this.currPage = 1;
       joinRoomBody.innerHTML = await this.getRoomList();
     });
     tournamentTab.addEventListener('click', async () => {
       this.mode = 'tournament';
+      this.currPage = 1;
       joinRoomBody.innerHTML = await this.getRoomList();
     });
 
     // 페이지네이션
     const prevBtn = document.getElementById('prevBtn');
     const nextBtn = document.getElementById('nextBtn');
-    const currPage = document.getElementById('currPage');
-    const totalPage = document.getElementById('totalPage');
-
     prevBtn.addEventListener('click', async () => {
       if (this.currPage === 1) return;
-      nextBtn.removeAttribute('disabled');
       this.currPage -= 1;
-      if (this.currPage === 1) {
-        prevBtn.setAttribute('disabled', 'true');
-      }
-      currPage.innerHTML = this.currPage;
       joinRoomBody.innerHTML = await this.getRoomList();
-      totalPage.innerHTML = this.totalPage;
     });
 
     nextBtn.addEventListener('click', async () => {
       if (this.currPage === this.totalPage) return;
-      prevBtn.removeAttribute('disabled');
       this.currPage += 1;
-      if (this.currPage === this.totalPage) {
-        nextBtn.setAttribute('disabled', 'true');
-      }
-      currPage.innerHTML = this.currPage;
       joinRoomBody.innerHTML = await this.getRoomList();
-      totalPage.innerHTML = this.totalPage;
     });
   }
 }

--- a/frontend/src/pages/game/JoinRoom.js
+++ b/frontend/src/pages/game/JoinRoom.js
@@ -1,5 +1,6 @@
 import PageComponent from '@component/PageComponent.js';
 import NavLink from '@component/navigation/NavLink';
+import BasicButton from '@component/button/BasicButton';
 import Fetch from '@/utils/Fetch';
 
 class JoinRoom extends PageComponent {
@@ -9,7 +10,7 @@ class JoinRoom extends PageComponent {
   }
 
   async getRoomLinks() {
-    const roomList = await Fetch.get('/roomList');
+    const roomList = await Fetch.get('/rumbleList');
 
     return roomList
       .map((room) => {
@@ -25,10 +26,19 @@ class JoinRoom extends PageComponent {
 
   async render() {
     const RoomLinks = await this.getRoomLinks();
+    const reloadBtn = BasicButton({
+      id: 'reloadBtn',
+      text: '> Reload',
+      classList:
+        'fs-2 position-absolute top-0 end-0 mt-2 me-2 btn-no-outline-hover',
+    });
 
     return `
       <div class="container h-100 p-3 game-room-border">
-        <h1 class="display-1 text-center">[ Room List ]</h1>
+        <div class="d-flex justify-content-center position-relative">
+          <h1 class="display-1 text-center">[ Room List ]</h1>
+          ${reloadBtn}
+        </div>
         <div class="d-flex justify-content-center h-75 overflow-auto">
           <div class="d-flex flex-column">
             ${RoomLinks}

--- a/frontend/src/pages/game/JoinRoom.js
+++ b/frontend/src/pages/game/JoinRoom.js
@@ -6,16 +6,22 @@ import Fetch from '@/utils/Fetch';
 class JoinRoom extends PageComponent {
   constructor() {
     super();
+    this.mode = 'rumble';
     this.setTitle('Join Room');
   }
 
-  async getRoomLinks() {
-    const roomList = await Fetch.get('/rumbleList');
+  async getRoomList() {
+    const roomList =
+      this.mode === 'rumble'
+        ? await Fetch.get('/rumbleList')
+        : await Fetch.get('/tournamentList');
+
+    const totalParty = this.mode === 'rumble' ? 2 : 4;
 
     return roomList
       .map((room) => {
         return NavLink({
-          text: `[ ${room.title} ] (${room.currentParty}/${room.totalParty})`,
+          text: `[ ${room.title} ] (${room.currentParty}/${totalParty})`,
           path: '/game/waiting',
           classList: 'btn btn-no-outline-hover fs-11 btn-arrow',
           disabled: false,
@@ -25,9 +31,9 @@ class JoinRoom extends PageComponent {
   }
 
   async render() {
-    const RoomLinks = await this.getRoomLinks();
-    const reloadBtn = BasicButton({
-      id: 'reloadBtn',
+    const RoomLinks = await this.getRoomList();
+    const reloadRoomBtn = BasicButton({
+      id: 'reloadRoomBtn',
       text: '> Reload',
       classList:
         'fs-2 position-absolute top-0 end-0 mt-2 me-2 btn-no-outline-hover',
@@ -37,10 +43,10 @@ class JoinRoom extends PageComponent {
       <div class="container h-100 p-3 game-room-border">
         <div class="d-flex justify-content-center position-relative">
           <h1 class="display-1 text-center">[ Room List ]</h1>
-          ${reloadBtn}
+          ${reloadRoomBtn}
         </div>
         <div class="d-flex justify-content-center h-75 overflow-auto">
-          <div class="d-flex flex-column">
+          <div id="joinRoomBody" class="d-flex flex-column">
             ${RoomLinks}
           </div>
         </div>
@@ -49,6 +55,15 @@ class JoinRoom extends PageComponent {
         </div>
       </div>
       `;
+  }
+
+  async afterRender() {
+    const reloadRoomBtn = document.getElementById('reloadRoomBtn');
+    const joinRoomBody = document.getElementById('joinRoomBody');
+
+    reloadRoomBtn.addEventListener('click', async () => {
+      joinRoomBody.innerHTML = await this.getRoomList();
+    });
   }
 }
 

--- a/frontend/src/pages/game/WaitingRoom.js
+++ b/frontend/src/pages/game/WaitingRoom.js
@@ -1,6 +1,6 @@
 import PageComponent from '@component/PageComponent.js';
 
-class CreateRoom extends PageComponent {
+class WaitingRoom extends PageComponent {
   constructor() {
     super();
     this.setTitle('Create Room');
@@ -9,13 +9,13 @@ class CreateRoom extends PageComponent {
   async render() {
     return `
       <div class="container h-100 p-3 game-room-border">
-        <h1 class="display-1 text-center">[ Room Setting ]</h1>
+        <h1 class="display-1 text-center">Welcome to 'title'</h1>
         <div>
-          create room
+          waiting room
         </div>
       </div>
       `;
   }
 }
 
-export default CreateRoom;
+export default WaitingRoom;

--- a/frontend/src/scss/styles.scss
+++ b/frontend/src/scss/styles.scss
@@ -57,6 +57,12 @@ input:-webkit-autofill:active {
       0 0 10px 0 $mint inset,
       0 0 10px 4px $mint;
   }
+
+}
+
+.btn-outline-light.active {
+  box-shadow: 0 0 10px 0 $mint inset,
+  0 0 10px 4px $mint;
 }
 
 .btn-no-outline-hover {

--- a/frontend/src/scss/styles.scss
+++ b/frontend/src/scss/styles.scss
@@ -173,3 +173,8 @@ input:-webkit-autofill:active {
     background-color: $bg-main;
   }
 }
+
+.game-room-border {
+  border: dashed $white;
+  border-width: 15px 0;
+}

--- a/frontend/src/utils/router.js
+++ b/frontend/src/utils/router.js
@@ -4,6 +4,7 @@ import Profile from '@pages/Profile';
 import Game from '@pages/game/Game';
 import CreateRoom from '@pages/game/CreateRoom';
 import JoinRoom from '@pages/game/JoinRoom';
+import WaitingRoom from '@pages/game/WaitingRoom';
 import Friends from '@pages/Friends';
 import NavBar from '@component/navigation/NavBar';
 import TokenManager from '@/utils/TokenManager';
@@ -23,6 +24,7 @@ export const router = async () => {
     '/game': Game,
     '/game/create': CreateRoom,
     '/game/join': JoinRoom,
+    '/game/waiting': WaitingRoom, // TODO: Waiting 추가
     '/friends': Friends,
     '/404': Home, // TODO: NotFound 추가
   };


### PR DESCRIPTION
<!-- PR Title은 [FEAT/FIX/STYLE/DOCS 등등] Title 형식으로 맞춰주세요 -->

<!-- PR 개요는 이슈링크로 대체합니다 -->
## ⭐️ 해당 이슈
- #35 

<!-- 구현사항, 변경사항 등 자세히 적어주세요 -->
<!-- 화면 변경사항이 있다면 해당 화면 이미지도 추가해주시면 좋아요 -->
## 📜 작업 내용
게임 방 목록은 모두 동적으로 innerText 변경하는 방식으로 구현했습니다
- 새로고침 버튼
- 탭 모드
- 페이지네이션
  - 클래스 내 변수로 관리하는 방식 사용했습니다
  - 첫 페이지와 마지막 페이지일 때 이동 버튼 비활성화 했습니다
<img width="400" alt="스크린샷 2024-05-14 오후 10 48 25" src="https://github.com/Retro-pong/Transcendence/assets/105159293/25fea80a-93e3-4700-8f3e-1091488367d6">
<img width="400" alt="스크린샷 2024-05-14 오후 10 50 16" src="https://github.com/Retro-pong/Transcendence/assets/105159293/fb11da8e-8f04-44cd-b9bb-51c4e8b1d7dc">

<!-- 이 부분은 자세히 리뷰해줬으면 하는 부분이 있다면 적어주세요 -->
## 📍 리뷰 요구사항
- 탭 스타일이 이상하지는 않은지 모르겠습니다
- 일반 모드일 땐 다 2명이라 인원을 보여줄 필요가 없을 것 같은데 없으면 허전해 보여서 일단 넣었습니다
- 일단 탭 이동 시에도 목록을 다시 받아오도록 구현했는데 새로고침 시에만 요청 보내는게 좋을지 이대로 두는게 좋을지 의견 부탁드립니다
