### PR TITLE
[Design] 게임 대기실 페이지 레이아웃

### DIFF
--- a/frontend/src/component/card/PlayerCard.js
+++ b/frontend/src/component/card/PlayerCard.js
@@ -1,0 +1,34 @@
+const PlayerCard = ({ id, name, status, role }) => {
+  const textColor = role === 'host' ? 'text-success' : '';
+  const statusMessage = {
+    ready: 'ready!',
+    waiting: 'waiting...',
+    playing: 'playing!',
+  };
+  return `
+    <div class="justify-content-center px-3 game-player-card-border" style="width: 85%;">
+      <div class="row">
+        <div class="col-md-8 align-self-center text-start fs-7">
+          <div class="text-break">
+            <div class="row">
+              <span class="${textColor}">Player ${id}</span>
+            </div>
+            <div class="row">
+              <span class="">${name}</span>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-4 align-content-center">
+          <div class="ratio ratio-1x1">
+            <img src="https://www.blueconomy.co.kr/news/photo/202402/2399_3001_921.png" class="img-fluid" alt="profile" style="object-fit: cover;" />
+          </div>
+        </div>
+      </div>
+      <div class="row align-self-center">
+        <span class="fs-7">< ${statusMessage[status]} ></span>
+      </div>
+    </div>
+  `;
+};
+
+export default PlayerCard;

--- a/frontend/src/component/contents/GameManual.js
+++ b/frontend/src/component/contents/GameManual.js
@@ -1,0 +1,11 @@
+const GameManual = () => {
+  return `
+    <div class="container-fluid text-center">
+      <p class="fs-10 text-break">
+        blah blah blah
+      </p>
+    </div>
+  `;
+};
+
+export default GameManual;

--- a/frontend/src/pages/game/JoinRoom.js
+++ b/frontend/src/pages/game/JoinRoom.js
@@ -34,7 +34,7 @@ class JoinRoom extends PageComponent {
             : `[ ${room.title} ] (${room.currentParty}/4)`;
         return NavLink({
           text,
-          path: '/game/waiting',
+          path: `/game/waiting?room=${room.id}&title=${room.title}&mode=${this.mode}`,
           classList: 'btn btn-no-outline-hover fs-11 btn-arrow',
         }).outerHTML;
       })

--- a/frontend/src/pages/game/WaitingRoom.js
+++ b/frontend/src/pages/game/WaitingRoom.js
@@ -1,15 +1,18 @@
 import PageComponent from '@component/PageComponent.js';
 import PlayerCard from '@component/card/PlayerCard';
+import BasicButton from '@component/button/BasicButton';
 
 class WaitingRoom extends PageComponent {
   constructor() {
     super();
-    this.setTitle('Create Room');
+    this.setTitle('Waiting Room');
   }
 
   async render() {
     const params = new URLSearchParams(document.location.search);
     const TITLE = params.get('title');
+    // TODO: 소켓으로 게임 방 정보 받아오기, 참가자가 아니면 홈으로 리다이렉트
+    const ROLE = 'host';
     const dummyPlayers = [
       {
         id: 1,
@@ -45,15 +48,27 @@ class WaitingRoom extends PageComponent {
         `;
       })
       .join('');
+    const StartButton = BasicButton({
+      id: 'startBtn',
+      text: '<< Start Game! >>',
+      classList: 'btn btn-no-outline-hover fs-10',
+      disabled: ROLE !== 'host',
+    });
+
     return `
       <div class="container h-100 p-3 game-room-border">
-        <h1 class="display-1 text-center">Welcome to<br /> [ ${TITLE} ]</h1>
-        <div class="d-flex justify-content-center align-items-center h-75">
-          <div class="container text-center w-100">
-            <div class="row row-cols-1 row-cols-md-2 g-3">
-              ${PlayerCards}
+        <div class="d-flex flex-column h-100">
+          <h1 class="display-1 text-center">Welcome to<br /> [ ${TITLE} ]</h1>
+          <div class="d-flex justify-content-center align-items-center h-75">
+            <div class="container text-center w-100">
+              <div class="row row-cols-1 row-cols-md-2 g-3">
+                ${PlayerCards}
+              </div>
             </div>
           </div>
+          <div class="d-flex justify-content-center align-items-center h-25">
+            ${StartButton}
+          <div>
         </div>
       </div>
       `;

--- a/frontend/src/pages/game/WaitingRoom.js
+++ b/frontend/src/pages/game/WaitingRoom.js
@@ -84,7 +84,7 @@ class WaitingRoom extends PageComponent {
           </div>
           <div class="d-flex justify-content-center align-items-center h-25">
             ${StartButton}
-          <div>
+          </div>
         </div>
       </div>
       `;

--- a/frontend/src/pages/game/WaitingRoom.js
+++ b/frontend/src/pages/game/WaitingRoom.js
@@ -1,4 +1,5 @@
 import PageComponent from '@component/PageComponent.js';
+import PlayerCard from '@component/card/PlayerCard';
 
 class WaitingRoom extends PageComponent {
   constructor() {
@@ -7,11 +8,52 @@ class WaitingRoom extends PageComponent {
   }
 
   async render() {
+    const params = new URLSearchParams(document.location.search);
+    const TITLE = params.get('title');
+    const dummyPlayers = [
+      {
+        id: 1,
+        name: 'hyobicho',
+        status: 'ready',
+        role: 'host',
+      },
+      {
+        id: 2,
+        name: 'hyungjpa',
+        status: 'ready',
+        role: 'guest',
+      },
+      {
+        id: 3,
+        name: 'wonjilee',
+        status: 'ready',
+        role: 'guest',
+      },
+      {
+        id: 4,
+        name: 'subinlee',
+        status: 'ready',
+        role: 'guest',
+      },
+    ];
+    const PlayerCards = dummyPlayers
+      .map((player) => {
+        return `
+          <div class="col d-flex align-items-center justify-content-center mb-2" >
+            ${PlayerCard(player)}
+          </div> 
+        `;
+      })
+      .join('');
     return `
       <div class="container h-100 p-3 game-room-border">
-        <h1 class="display-1 text-center">Welcome to 'title'</h1>
-        <div>
-          waiting room
+        <h1 class="display-1 text-center">Welcome to<br /> [ ${TITLE} ]</h1>
+        <div class="d-flex justify-content-center align-items-center h-75">
+          <div class="container text-center w-100">
+            <div class="row row-cols-1 row-cols-md-2 g-3">
+              ${PlayerCards}
+            </div>
+          </div>
         </div>
       </div>
       `;

--- a/frontend/src/pages/game/WaitingRoom.js
+++ b/frontend/src/pages/game/WaitingRoom.js
@@ -1,6 +1,9 @@
 import PageComponent from '@component/PageComponent.js';
 import PlayerCard from '@component/card/PlayerCard';
 import BasicButton from '@component/button/BasicButton';
+import OpenModalButton from '@component/button/OpenModalButton';
+import ModalComponent from '@component/modal/ModalComponent';
+import GameManual from '@component/contents/GameManual';
 
 class WaitingRoom extends PageComponent {
   constructor() {
@@ -54,11 +57,24 @@ class WaitingRoom extends PageComponent {
       classList: 'btn btn-no-outline-hover fs-10',
       disabled: ROLE !== 'host',
     });
-
+    const ManualButton = OpenModalButton({
+      text: '> Manual',
+      classList:
+        'btn btn-no-outline-hover fs-2 position-absolute top-0 end-0 mt-2 me-2',
+      modalId: '#gameManualModal',
+    });
+    const GameManualModal = ModalComponent({
+      borderColor: 'mint',
+      title: 'How To Play',
+      modalId: 'gameManualModal',
+      content: GameManual(),
+      buttonList: [],
+    });
     return `
       <div class="container h-100 p-3 game-room-border">
-        <div class="d-flex flex-column h-100">
+        <div class="d-flex flex-column h-100 position-relative">
           <h1 class="display-1 text-center">Welcome to<br /> [ ${TITLE} ]</h1>
+          ${ManualButton} ${GameManualModal}
           <div class="d-flex justify-content-center align-items-center h-75">
             <div class="container text-center w-100">
               <div class="row row-cols-1 row-cols-md-2 g-3">

--- a/frontend/src/scss/styles.scss
+++ b/frontend/src/scss/styles.scss
@@ -161,3 +161,8 @@ input:-webkit-autofill:active {
   border: dashed $white;
   border-width: 15px 0;
 }
+
+.game-player-card-border {
+  border: double $white;
+  border-width: 0 15px;
+}


### PR DESCRIPTION
<!-- PR Title은 [FEAT/FIX/STYLE/DOCS 등등] Title 형식으로 맞춰주세요 -->

<!-- PR 개요는 이슈링크로 대체합니다 -->
## ⭐️ 해당 이슈
- #47 

<!-- 구현사항, 변경사항 등 자세히 적어주세요 -->
<!-- 화면 변경사항이 있다면 해당 화면 이미지도 추가해주시면 좋아요 -->
## 📜 작업 내용
- joinRoom에서 이동 시 쿼리 스트링으로 간단한 방 정보 받도록 했습니다
- 상단 매뉴얼 버튼 클릭 시 게임 플레이 방법 설명 모달을 띄웁니다
- 방장인 유저는 초록색으로 표시했습니다
- start button은 방장인 경우에만 활성화되도록 했습니다
- 플레이어 카드 보더는 dashed로 하니까 조금 어지러운 것 같아서 double로 설정했습니다
<img width="400" alt="스크린샷 2024-05-16 오전 2 10 57" src="https://github.com/Retro-pong/Transcendence/assets/105159293/00cb36e8-6197-45e7-a843-1054114d0663">


<!-- 이 부분은 자세히 리뷰해줬으면 하는 부분이 있다면 적어주세요 -->
## 📍 리뷰 요구사항
- 일단 정해진 게 없어 피그마대로만 구현했는데 방 만들 때 설정한 옵션들은 안보여줘도 괜찮을지 모르겠네요. 아니면 매뉴얼 버튼 아래 버튼 하나 더 만들어서 모달 띄워서 보여줘도 괜찮을 것 같은데 추후 의논 필요할 것 같습니다!
