### PR TITLE
[Fix] Friend, Profile fetch 에러 처리 추가

### DIFF
--- a/frontend/src/pages/Friends.js
+++ b/frontend/src/pages/Friends.js
@@ -206,7 +206,7 @@ class Friends extends PageComponent {
     return `
       ${FriendWaitModal}
       ${FriendAddModal}
-      <div class="d-flex justify-content-between position-sticky top-0 z-1">
+      <div class="d-md-flex justify-content-between position-sticky top-0 z-1">
         <h1 class="fs-14">Friends</h1>
         <div class="d-flex flex-row pe-5">
           ${FriendPageButtons()}

--- a/frontend/src/pages/Friends.js
+++ b/frontend/src/pages/Friends.js
@@ -20,13 +20,15 @@ class Friends extends PageComponent {
 
   async getFriends() {
     const URL = `/friends/friend_list/?limit=${this.limit}&offset=${this.offset}`;
-    const response = await Fetch.get(URL).catch(() => {
+    try {
+      const response = await Fetch.get(URL);
+      this.totalPage = response.total;
+      return response.friends;
+    } catch (err) {
       document.getElementById('pagination').classList.add('d-none');
       ErrorHandler.setToast('Failed to get friends list');
       return [];
-    });
-    this.totalPage = response.total;
-    return response.friends || [];
+    }
   }
 
   async getPageData() {

--- a/frontend/src/pages/Friends.js
+++ b/frontend/src/pages/Friends.js
@@ -26,7 +26,7 @@ class Friends extends PageComponent {
       return [];
     });
     this.totalPage = response.total;
-    return response.friends;
+    return response.friends || [];
   }
 
   async getPageData() {

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -14,10 +14,12 @@ class Profile extends PageComponent {
   constructor() {
     super();
     this.setTitle('Profile');
+    this.hasError = false;
   }
 
   async getProfile() {
     return Fetch.get('/users/profile/').catch(() => {
+      this.hasError = true;
       ErrorHandler.setToast('Failed to get user info');
       return [];
     });
@@ -183,6 +185,7 @@ class Profile extends PageComponent {
 
   async afterRender() {
     await this.initPageData();
+    if (this.hasError) return;
     this.onEditClick();
     this.onProfileImgClick();
     this.onEditProfileClick();


### PR DESCRIPTION
<!-- PR Title은 [FEAT/FIX/STYLE/DOCS 등등] Title 형식으로 맞춰주세요 -->

<!-- PR 개요는 이슈링크로 대체합니다 -->
## ⭐️ 해당 이슈
- #151 

<!-- 구현사항, 변경사항 등 자세히 적어주세요 -->
<!-- 화면 변경사항이 있다면 해당 화면 이미지도 추가해주시면 좋아요 -->
## 📜 작업 내용
- 친구 목록 불러올 때 response.friends 에러 catch 하는 부분이 없어서 try catch 로 처리했습니다
- profile에서 fetch 에러 시 뒤에 이벤트 불러오는 곳에서 에러가 나서 변수 추가해서 실행 안되도록 수정했습니다

<!-- 이 부분은 자세히 리뷰해줬으면 하는 부분이 있다면 적어주세요 -->
## 📍 리뷰 요구사항
- fetch 에러가 콘솔에 찍히는 걸 수정하려고 이슈 팠는데 브라우저에서 띄우는거라 처리하지 않아도 되는 것 같아요
- refresh token 지워지지 않은 상태로 컨테이너 삭제하고 다시 실행하면 확인할 수 있습니다  
- 실제로는 발생할 경우가 없는 에러 같은데 일단 이슈 판 김에 수정했습니다
