### PR TITLE
[Feat] 응답 에러 코드 추가

### DIFF
--- a/frontend/src/pages/Friends.js
+++ b/frontend/src/pages/Friends.js
@@ -67,15 +67,21 @@ class Friends extends PageComponent {
           friend_name: friendName,
           request_patch: '1',
         })
-          .then(async () => {
-            await this.initPageData(this);
-            this.onReloadButtonClick(this);
-            this.onPaginationClick(this);
-            ToastHandler.setToast('Friend accepted');
-            document.querySelector(`[data-wait-item="${friendName}"]`).remove();
+          .then(async (res) => {
+            if (res.status === 201) {
+              await this.initPageData(this);
+              this.onReloadButtonClick(this);
+              this.onPaginationClick(this);
+              ToastHandler.setToast('Friend accepted');
+              document
+                .querySelector(`[data-wait-item="${friendName}"]`)
+                .remove();
+            }
           })
-          .catch(() => {
-            ToastHandler.setToast('Failed to accept friend');
+          .catch((err) => {
+            ToastHandler.setToast(
+              `${err.message || 'Failed to accept friend'} [${err.code}]`
+            );
           });
       });
     });
@@ -89,12 +95,18 @@ class Friends extends PageComponent {
           friend_name: friendName,
           request_patch: '0',
         })
-          .then(() => {
-            ToastHandler.setToast('Friend rejected');
-            document.querySelector(`[data-wait-item="${friendName}"]`).remove();
+          .then((res) => {
+            if (res.status === 200) {
+              ToastHandler.setToast('Friend rejected');
+              document
+                .querySelector(`[data-wait-item="${friendName}"]`)
+                .remove();
+            }
           })
-          .catch(() => {
-            ToastHandler.setToast('Failed to reject friend');
+          .catch((err) => {
+            ToastHandler.setToast(
+              `${err.message || 'Failed to reject friend'} [${err.code}]`
+            );
           });
       });
     });
@@ -105,14 +117,17 @@ class Friends extends PageComponent {
       btn.addEventListener('click', async (e) => {
         const friendName = e.target.dataset.nick;
         await Fetch.patch('/friends/add/', { friend_name: friendName })
-          .then(() => {
-            ToastHandler.setToast(`friend request ${friendName}`);
+          .then((res) => {
+            if (res.status === 200) {
+              ToastHandler.setToast(`${res.error} ${friendName}`);
+            }
+            if (res.status === 201) {
+              ToastHandler.setToast(`friend request ${friendName}`);
+            }
           })
-          .catch((error) => {
+          .catch((err) => {
             ToastHandler.setToast(
-              error.status === 409
-                ? error.message
-                : `failed to friend request ${friendName}`
+              `${err.message || 'Failed to send friend request'} [${err.code}]`
             );
           });
       });
@@ -182,8 +197,10 @@ class Friends extends PageComponent {
             this.onFriendRequestBtnClick();
             friendSearchList.scrollIntoView({ behavior: 'smooth' });
           })
-          .catch(() => {
-            ToastHandler.setToast('search failed');
+          .catch((err) => {
+            ToastHandler.setToast(
+              `${err.message || 'Search Failed'} [${err.code}]`
+            );
           });
       }, 1000)
     );
@@ -194,12 +211,16 @@ class Friends extends PageComponent {
       btn.addEventListener('click', async (e) => {
         const friendName = e.target.dataset.nick;
         Fetch.patch(`/friends/friend_list/`, { friend_name: friendName })
-          .then(() => {
-            ToastHandler.setToast(`Friend ${friendName} deleted`);
+          .then((res) => {
+            ToastHandler.setToast(
+              res.message || `Friend ${friendName} deleted`
+            );
             this.initPageData(this);
           })
-          .catch(() => {
-            ToastHandler.setToast(`Failed to delete friend ${friendName}`);
+          .catch((err) => {
+            ToastHandler.setToast(
+              `${err.message || 'Failed to delete friend'} [${err.code}]`
+            );
           });
       });
     });

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -62,11 +62,12 @@ class Login extends PageComponent {
       return;
     }
     await Fetch.post('/login/email/login/', { email, password })
-      .then(() => {
+      .then((res) => {
         loginModal.show();
+        ToastHandler.setToast(res.message || 'Verification code Sent');
       })
       .catch((err) => {
-        ToastHandler.setToast(err.error || 'Login Failed');
+        ToastHandler.setToast(`${err.message || 'Login Failed'} [${err.code}]`);
       });
   }
 
@@ -88,9 +89,12 @@ class Login extends PageComponent {
         TokenManager.storeToken(data.access_token);
         loginModal.hide();
         Router.navigateTo('/');
+        ToastHandler.setToast(data.message || 'Login Successful');
       })
       .catch((err) => {
-        ToastHandler.setToast(err.error || 'Verification Failed');
+        ToastHandler.setToast(
+          `${err.message || 'Verification Failed'} [${err.code}]`
+        );
       });
   }
 
@@ -166,7 +170,9 @@ class Login extends PageComponent {
           })
           .catch((err) => {
             this.email = '';
-            ToastHandler.setToast(err.error || 'Registration Failed');
+            ToastHandler.setToast(
+              `${err.message || 'Registration Failed'} [${err.code}]`
+            );
           });
       });
   }
@@ -181,14 +187,16 @@ class Login extends PageComponent {
 
         const verifyModal = Modal.getOrCreateInstance('#emailVerifyModal');
         await Fetch.post('/login/email/register/verify/', { email, code })
-          .then(() => {
-            ToastHandler.setToast('Email Verification Successful');
+          .then((res) => {
+            ToastHandler.setToast(res.message || 'Email Verification Successful');
             document.getElementById('emailVerifyForm').reset();
             verifyModal.hide();
             this.email = '';
           })
           .catch((err) => {
-            ToastHandler.setToast(err.error || 'Verification Failed');
+            ToastHandler.setToast(
+              `${err.message || 'Verification Failed'} [${err.code}]`
+            );
           });
       });
   }
@@ -199,11 +207,15 @@ class Login extends PageComponent {
       .then((data) => {
         TokenManager.storeToken(data.access_token);
         Router.navigateTo('/');
+        ToastHandler.setToast(data.message || '42 Login Successful');
       })
-      .catch(() => {
+      .catch((err) => {
         ToastHandler.setToast('42 Login Failed');
         TokenManager.clearToken();
         Router.navigateTo('/login');
+        ToastHandler.setToast(
+          `${err.message || '42 Login Failed'} [${err.code}]`
+        );
       });
   }
 

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -132,12 +132,16 @@ class Profile extends PageComponent {
         username: nick.toLowerCase(),
         comment,
       })
-        .then(() => {
-          ToastHandler.setToast('Profile Update Successful');
+        .then((res) => {
+          ToastHandler.setToast(res.message || 'Profile Update Successful');
           editProfileModal.hide();
           this.afterRender();
         })
-        .catch(() => ToastHandler.setToast('Profile Update Failed'));
+        .catch((err) =>
+          ToastHandler.setToast(
+            `${err.message || 'Profile Update Failed'} [${err.code}]`
+          )
+        );
     });
   }
 
@@ -163,11 +167,17 @@ class Profile extends PageComponent {
         formData.append('image', resizeImg);
 
         await Fetch.patch('/users/profile/upload/', formData, 'image')
-          .then(() => {
-            ToastHandler.setToast('Profile Image Update Successful');
+          .then((res) => {
+            ToastHandler.setToast(
+              res.message || 'Profile Image Update Successful'
+            );
             this.afterRender();
           })
-          .catch(() => ToastHandler.setToast('Profile Image Update Failed'));
+          .catch((err) =>
+            ToastHandler.setToast(
+              `${err.message || 'Profile Image Update Failed'} [${err.code}]`
+            )
+          );
       });
   }
 

--- a/frontend/src/utils/Fetch.js
+++ b/frontend/src/utils/Fetch.js
@@ -50,7 +50,7 @@ class Fetch {
       }
       return response.json().then((err) => {
         console.error(`GET(${url}) ERROR:`, err);
-        throw err;
+        throw { code: response.status, message: err.error || err.detail || '' };
       });
     }
     return response.json();
@@ -72,7 +72,7 @@ class Fetch {
       }
       return response.json().then((err) => {
         console.error(`POST(${url}) ERROR:`, err);
-        throw err;
+        throw { code: response.status, message: err.error || err.detail || '' };
       });
     }
     return response.json().catch(() => '');
@@ -99,7 +99,7 @@ class Fetch {
       }
       return response.json().then((err) => {
         console.error(`PATCH(${url}) ERROR:`, err);
-        throw { message: err.error, status: response.status };
+        throw { code: response.status, message: err.error || err.detail || '' };
       });
     }
     return response.json().catch(() => '');

--- a/frontend/src/utils/TokenManager.js
+++ b/frontend/src/utils/TokenManager.js
@@ -42,9 +42,9 @@ class TokenManager {
         this.storeToken(res.access_token);
       })
       .catch((err) => {
-        if (err.error !== 'No refresh token.') {
-          ToastHandler.setToast('You need to login');
-        }
+        ToastHandler.setToast(
+          `${err.message || 'You need to login'} [${err.code}]`
+        );
         this.clearToken();
         Router.navigateTo('/login');
       });
@@ -52,11 +52,15 @@ class TokenManager {
 
   static async logout() {
     await Fetch.post('/login/logout/')
-      .then(() => {
+      .then((res) => {
+        ToastHandler.setToast(res.message || 'Logout Successful');
         this.clearToken();
       })
-      .catch(() => {
+      .catch((err) => {
         this.clearToken();
+        ToastHandler.setToast(
+          `${err.message || 'Logout Failed'} [${err.code}]`
+        );
       });
   }
 }

--- a/frontend/src/utils/TokenManager.js
+++ b/frontend/src/utils/TokenManager.js
@@ -58,9 +58,6 @@ class TokenManager {
       })
       .catch((err) => {
         this.clearToken();
-        ToastHandler.setToast(
-          `${err.message || 'Logout Failed'} [${err.code}]`
-        );
       });
   }
 }


### PR DESCRIPTION
<!-- PR Title은 [FEAT/FIX/STYLE/DOCS 등등] Title 형식으로 맞춰주세요 -->

<!-- PR 개요는 이슈링크로 대체합니다 -->
## ⭐️ 해당 이슈
- #186

<!-- 구현사항, 변경사항 등 자세히 적어주세요 -->
<!-- 화면 변경사항이 있다면 해당 화면 이미지도 추가해주시면 좋아요 -->
## 📜 작업 내용
- 로그인, 프로필, 친구 토스트 메시지 수정
- Fetch 에서 throw할 때 code와 message 합친 객체로 throw
- 상태코드가 필요할까봐 일단은 code와 message를 둘 다 던져주는 식으로 처리했습니다.

<!-- 이 부분은 자세히 리뷰해줬으면 하는 부분이 있다면 적어주세요 -->
## 📍 리뷰 요구사항
- throw하는 에러 객체를 메시지로 만들어서 throw 해버리는게 나은지 모르겠습니다.
- 200대 응답에도 message를 다 담아주셔서 일단 다 추가해놨습니다.(로그인, 로그아웃, 프로필 수정 등)

