### PR TITLE
[Feat] 게임 매뉴얼 추가 

### DIFF
--- a/frontend/src/component/contents/GameManual.js
+++ b/frontend/src/component/contents/GameManual.js
@@ -1,9 +1,23 @@
 const GameManual = () => {
+  const coloredText = (text) => `<span class="text-info">${text}</span>`;
   return `
-    <div class="container-fluid text-center">
-      <p class="fs-10 text-break">
-        blah blah blah
-      </p>
+    <div class="container-fluid">
+      <div class="d-flex flex-column justify-content-center px-3">
+        <h1 class="fs-11 text-success">Remote Play</h1>
+        <p class="fs-8 text-break">
+         ${coloredText('mouse')} control
+        </p>
+        <h1 class="fs-11 text-success">Local Play</h1>
+        <p class="fs-8 text-break">
+          Player 1 key
+          <br />
+          ${coloredText('[ W / S / A / D ]')}
+          <br />
+          Player 2 key
+          <br />
+          ${coloredText('[ Up / Down / Left / Right ]')}
+        </p>
+      </div>
     </div>
   `;
 };

--- a/frontend/src/pages/game/Game.js
+++ b/frontend/src/pages/game/Game.js
@@ -1,5 +1,8 @@
 import PageComponent from '@component/PageComponent.js';
 import NavLink from '@component/navigation/NavLink';
+import OpenModalButton from '@component/button/OpenModalButton';
+import ModalComponent from '@component/modal/ModalComponent';
+import GameManual from '@component/contents/GameManual';
 
 class Game extends PageComponent {
   constructor() {
@@ -26,10 +29,26 @@ class Game extends PageComponent {
       classList: 'btn btn-no-outline-hover fs-15 btn-arrow',
     }).outerHTML;
 
+    const ManualButton = OpenModalButton({
+      text: 'How To Play',
+      classList: 'btn btn-no-outline-hover fs-10 manualBtn',
+      modalId: '#gameManualModal',
+    });
+
+    const GameManualModal = ModalComponent({
+      borderColor: 'mint',
+      title: 'How To Play',
+      modalId: 'gameManualModal',
+      content: GameManual(),
+      buttonList: [],
+    });
+
     return `
+    ${GameManualModal}
     <div class="d-flex flex-column justify-content-around align-items-center h-90">
       <h1 class="text-center fs-18">Get ready for the next battle!</h1>
       <div class="d-flex flex-column">
+        ${ManualButton}
         ${CreateRoomButton}
         ${JoinRoomButton}
         ${LocalPlayButton}

--- a/frontend/src/pages/game/WaitingRoom.js
+++ b/frontend/src/pages/game/WaitingRoom.js
@@ -1,8 +1,5 @@
 import PageComponent from '@component/PageComponent.js';
 import PlayerCard from '@component/card/PlayerCard';
-import OpenModalButton from '@component/button/OpenModalButton';
-import ModalComponent from '@component/modal/ModalComponent';
-import GameManual from '@component/contents/GameManual';
 import SocketManager from '@/utils/SocketManager';
 import Router from '@/utils/Router';
 import TokenManager from '@/utils/TokenManager';
@@ -26,25 +23,10 @@ class WaitingRoom extends PageComponent {
   }
 
   async render() {
-    const ManualButton = OpenModalButton({
-      text: '> Manual',
-      classList:
-        'btn btn-no-outline-hover fs-2 position-absolute top-0 end-0 mt-2 me-2 d-none d-md-block',
-      modalId: '#gameManualModal',
-    });
-    const GameManualModal = ModalComponent({
-      borderColor: 'mint',
-      title: 'How To Play',
-      modalId: 'gameManualModal',
-      content: GameManual(),
-      buttonList: [],
-    });
     return `
-      ${GameManualModal}
       <div class="container h-100 p-3 game-room-border">
         <div class="d-flex flex-column h-100 position-relative">
           <h1 id="room-title" class="fs-15 text-center">Welcome to<br />[ ${this.roomTitle} ]</h1>
-          ${ManualButton}
           <div class="container overflow-auto h-100">
             <div id="player-container" class="row row-cols-1 row-cols-md-2 g-1">
               ${this.players.map((player) => PlayerCard(player)).join('')}

--- a/frontend/src/scss/styles.scss
+++ b/frontend/src/scss/styles.scss
@@ -282,3 +282,9 @@ canvas {
 @keyframes changeColor {
   0%, 100% { color: $mint; }
 }
+
+.manualBtn {
+  &:hover {
+    color: $mint;
+  }
+}


### PR DESCRIPTION
<!-- PR Title은 [FEAT/FIX/STYLE/DOCS 등등] Title 형식으로 맞춰주세요 -->

<!-- PR 개요는 이슈링크로 대체합니다 -->
## ⭐️ 해당 이슈
- #234 

<!-- 구현사항, 변경사항 등 자세히 적어주세요 -->
<!-- 화면 변경사항이 있다면 해당 화면 이미지도 추가해주시면 좋아요 -->
## 📜 작업 내용
- 게임 매뉴얼 버튼을 대기실에서 게임 페이지로 옮겼습니다
- 뭘 적어야할지 몰라서 간단히 패들 움직이는 방법만 적었습니다
<img width="400" alt="스크린샷 2024-06-18 오전 12 09 06" src="https://github.com/Retro-pong/Transcendence/assets/105159293/b9b115db-cc71-4b8e-b0d3-4b99bbea6d7b">

<!-- 이 부분은 자세히 리뷰해줬으면 하는 부분이 있다면 적어주세요 -->
## 📍 리뷰 요구사항
- 디자인이 이상하거나 추가해야할 내용이 있다면 알려주세요!
