### PR TITLE
[Feat] 로컬 게임 설정, 모달 추가

### DIFF
--- a/frontend/src/pages/game/PlayGame.js
+++ b/frontend/src/pages/game/PlayGame.js
@@ -100,7 +100,8 @@ class PlayGame extends PageComponent {
     // local game
     if (!this.gameMode) {
       this.gameManger.localGameSetting();
-      this.gameManger.localGameStart();
+      this.gameManger.localGameRender();
+      this.gameManger.localStartRendering();
     }
     // multi game
     else {

--- a/frontend/src/utils/game/localGame.js
+++ b/frontend/src/utils/game/localGame.js
@@ -1,10 +1,26 @@
+import { Modal } from 'bootstrap';
 import hitChangeColor from '@/utils/game/utils/hitChangeColor';
 import checkPaddleHit from '@/utils/game/utils/checkPaddleHit';
 import localGameStartSetting from '@/utils/game/utils/localGameStartSetting';
 
-function localGame(scene, objects, localGameInfo) {
+function localGame(scene, objects, localGameInfo, gameSpeed, renderRequestId) {
   let newLocalGameInfo = { ...localGameInfo };
   newLocalGameInfo.hitStatus = { ...localGameInfo.hitStatus };
+
+  const redScore = parseInt(objects.redPlayerScore.innerText, 10);
+  const blueScore = parseInt(objects.bluePlayerScore.innerText, 10);
+
+  if (redScore >= 5 || blueScore >= 5) {
+    cancelAnimationFrame(renderRequestId);
+    const gameResultModal = Modal.getOrCreateInstance('#gameResultModal');
+    const gameResult = document.querySelector('#gameResult');
+    const winner = redScore > blueScore ? 'red' : 'blue';
+    gameResult.innerText = `${winner} Win!`;
+    gameResult.classList.add(winner === 'red' ? 'text-danger' : 'text-primary');
+    gameResultModal.show();
+    return newLocalGameInfo;
+  }
+
   if (objects.ball) {
     if (newLocalGameInfo.start !== 'off') {
       newLocalGameInfo = localGameStartSetting(newLocalGameInfo, objects.ball);
@@ -57,7 +73,7 @@ function localGame(scene, objects, localGameInfo) {
         !newLocalGameInfo.hitStatus.redPaddleHit &&
         !newLocalGameInfo.hitStatus.bluePaddleHit
       ) {
-        newLocalGameInfo.v = 2.2;
+        newLocalGameInfo.v = 1.2 + 0.3 * gameSpeed;
       }
 
       // 벽에 부딪히면 방향 바꾸기

--- a/frontend/src/utils/game/localGame.js
+++ b/frontend/src/utils/game/localGame.js
@@ -41,7 +41,7 @@ function localGame(scene, objects, localGameInfo, gameSpeed, renderRequestId) {
         objects.ballPlane.position.z
       );
       // 패들에 부딪히면 방향 바꾸기
-      if (objects.ball.position.x > 19.7 && objects.ball.position.x < 20.3) {
+      if (objects.ball.position.x > 19.5 && objects.ball.position.x < 20.5) {
         if (!checkPaddleHit('red', scene)) {
           document.getElementById('player2Score').innerText = (
             parseInt(objects.bluePlayerScore.innerText, 10) + 1
@@ -52,7 +52,7 @@ function localGame(scene, objects, localGameInfo, gameSpeed, renderRequestId) {
           newLocalGameInfo.hitStatus.redPaddleHit = 1;
         }
       }
-      if (objects.ball.position.x < -19.7 && objects.ball.position.x > -20.3) {
+      if (objects.ball.position.x < -19.5 && objects.ball.position.x > -20.5) {
         if (!checkPaddleHit('blue', scene)) {
           document.getElementById('player1Score').innerText = (
             parseInt(objects.redPlayerScore.innerText, 10) + 1
@@ -77,19 +77,19 @@ function localGame(scene, objects, localGameInfo, gameSpeed, renderRequestId) {
       }
 
       // 벽에 부딪히면 방향 바꾸기
-      if (objects.ball.position.z < -7 && objects.ball.position.z > -8) {
+      if (objects.ball.position.z < -6.8 && objects.ball.position.z > -8.2) {
         newLocalGameInfo.c *= -1;
         newLocalGameInfo.hitStatus.leftWallHit = 1;
       }
-      if (objects.ball.position.z > 7 && objects.ball.position.z < 8) {
+      if (objects.ball.position.z > 6.8 && objects.ball.position.z < 8.2) {
         newLocalGameInfo.c *= -1;
         newLocalGameInfo.hitStatus.rightWallHit = 1;
       }
-      if (objects.ball.position.y > 4.5 && objects.ball.position.y < 5.5) {
+      if (objects.ball.position.y > 4.2 && objects.ball.position.y < 5.7) {
         newLocalGameInfo.b *= -1;
         newLocalGameInfo.hitStatus.topWallHit = 1;
       }
-      if (objects.ball.position.y < -4.5 && objects.ball.position.y > -5.5) {
+      if (objects.ball.position.y < -4.2 && objects.ball.position.y > -5.7) {
         newLocalGameInfo.b *= -1;
         newLocalGameInfo.hitStatus.bottomWallHit = 1;
       }

--- a/frontend/src/utils/game/setting/createGameObject.js
+++ b/frontend/src/utils/game/setting/createGameObject.js
@@ -6,26 +6,9 @@ function createGameObject(scene, ballColor) {
 
   // ball
   const ballGeometry = new THREE.SphereGeometry(1, 32, 16);
-  const colors = [];
-  const color1 = new THREE.Color(ballColor);
-  const color2 = new THREE.Color(0xffffff);
-
-  for (let i = 0; i < ballGeometry.attributes.position.count; i += 1) {
-    const y = ballGeometry.attributes.position.getY(i);
-    const alpha = (y + 1) / 6; // Normalize y value to range [0, 1]
-
-    const color = new THREE.Color();
-    color.lerpColors(color1, color2, alpha);
-    colors.push(color.r, color.g, color.b);
-  }
-
-  ballGeometry.setAttribute(
-    'color',
-    new THREE.Float32BufferAttribute(colors, 3)
-  );
-
-  const ballMaterial = new THREE.MeshStandardMaterial({
-    vertexColors: true,
+  const ballMaterial = new THREE.MeshPhongMaterial({
+    color: ballColor,
+    shininess: 100,
   });
 
   const ball = new THREE.Mesh(ballGeometry, ballMaterial);

--- a/frontend/src/utils/game/setting/localGameCustomSetting.js
+++ b/frontend/src/utils/game/setting/localGameCustomSetting.js
@@ -1,0 +1,76 @@
+const localGameCustomSetting = (gameManager) => {
+  const scoreContainer = document.getElementById('scoreContainer');
+
+  const openSettingButton = document.createElement('button');
+  openSettingButton.id = 'openSettingButton';
+  openSettingButton.className = 'btn btn-outline-light w-100 my-1 fs-3';
+  openSettingButton.innerText = 'Open Setting - Pause Game';
+
+  openSettingButton.addEventListener('click', () => {
+    const buttonContainer = document.getElementById('buttonContainer');
+    if (openSettingButton.innerText === 'Open Setting - Pause Game') {
+      openSettingButton.innerText = 'Close Setting - Restart Game';
+      buttonContainer.classList.remove('d-none');
+      gameManager.localStopRendering();
+    } else {
+      openSettingButton.innerText = 'Open Setting - Pause Game';
+      buttonContainer.classList.add('d-none');
+      gameManager.resetGameScore();
+      gameManager.localStartRendering();
+    }
+  });
+
+  const buttonContainer = document.createElement('div');
+  buttonContainer.id = 'buttonContainer';
+  buttonContainer.className =
+    'd-flex flex-column align-items-center w-100 fs-10 d-none border border-success border-5 rounded bg-dark my-3';
+
+  const mapButton = document.createElement('button');
+  const ballColorButton = document.createElement('button');
+  const speedButton = document.createElement('button');
+
+  buttonContainer.append(speedButton);
+  buttonContainer.append(ballColorButton);
+  buttonContainer.append(mapButton);
+
+  mapButton.id = 'localMapButton';
+  ballColorButton.id = 'localBallColorButton';
+  speedButton.id = 'localSpeedButton';
+
+  mapButton.className = 'btn btn-outline-light fs-8 w-100';
+  ballColorButton.className = 'btn btn-outline-light fs-8 w-100';
+  speedButton.className = 'btn btn-outline-light fs-8 w-100';
+
+  mapButton.innerText = 'Mountain';
+  ballColorButton.innerText = '0x0000ff';
+  speedButton.innerText = '3';
+
+  mapButton.addEventListener('click', () => {
+    if (mapButton.innerText === 'Mountain') {
+      mapButton.innerText = 'Futuristic Horizon';
+    } else if (mapButton.innerText === 'Futuristic Horizon') {
+      mapButton.innerText = 'Pixel Rain';
+    } else {
+      mapButton.innerText = 'Mountain';
+    }
+    gameManager.setLocalGameMap(mapButton.innerText);
+  });
+
+  ballColorButton.addEventListener('click', () => {
+    const randomColor = Math.floor(Math.random() * 16777215).toString(16);
+    ballColorButton.innerText = `0x${randomColor.padStart(6, '0')}`;
+    gameManager.setLocalGameBallColor(parseInt(ballColorButton.innerText, 16));
+  });
+
+  speedButton.addEventListener('click', () => {
+    const curSpeed = parseInt(speedButton.innerText, 10);
+    speedButton.innerText = curSpeed + 1 > 5 ? '1' : (curSpeed + 1).toString();
+    gameManager.setLocalGameSpeed(parseInt(speedButton.innerText, 10));
+    gameManager.resetLocalGameInfo();
+  });
+
+  scoreContainer.append(openSettingButton);
+  scoreContainer.append(buttonContainer);
+};
+
+export default localGameCustomSetting;

--- a/frontend/src/utils/game/setting/localGameCustomSetting.js
+++ b/frontend/src/utils/game/setting/localGameCustomSetting.js
@@ -15,6 +15,7 @@ const localGameCustomSetting = (gameManager) => {
     } else {
       openSettingButton.innerText = 'Open Setting - Pause Game';
       buttonContainer.classList.add('d-none');
+      document.getElementById('gameCanvas').focus();
       gameManager.resetGameScore();
       gameManager.localStartRendering();
     }

--- a/frontend/src/utils/game/setting/localGameCustomSetting.js
+++ b/frontend/src/utils/game/setting/localGameCustomSetting.js
@@ -43,8 +43,10 @@ const localGameCustomSetting = (gameManager) => {
   speedButton.className = 'btn btn-outline-light fs-8 w-100';
 
   mapButton.innerText = 'Mountain';
-  ballColorButton.innerText = '0x0000ff';
-  speedButton.innerText = '3';
+  ballColorButton.innerText = 'BALL COLOR';
+  speedButton.innerText = 'speed X3';
+
+  ballColorButton.style.color = `#0000ff`;
 
   mapButton.addEventListener('click', () => {
     if (mapButton.innerText === 'Mountain') {
@@ -59,14 +61,16 @@ const localGameCustomSetting = (gameManager) => {
 
   ballColorButton.addEventListener('click', () => {
     const randomColor = Math.floor(Math.random() * 16777215).toString(16);
-    ballColorButton.innerText = `0x${randomColor.padStart(6, '0')}`;
-    gameManager.setLocalGameBallColor(parseInt(ballColorButton.innerText, 16));
+    const hexColor = parseInt(`0x${randomColor.padStart(6, '0')}`, 16);
+    ballColorButton.innerText = `BALL COLOR`;
+    ballColorButton.style.color = `#${randomColor}`;
+    gameManager.setLocalGameBallColor(hexColor);
   });
 
   speedButton.addEventListener('click', () => {
-    const curSpeed = parseInt(speedButton.innerText, 10);
-    speedButton.innerText = curSpeed + 1 > 5 ? '1' : (curSpeed + 1).toString();
-    gameManager.setLocalGameSpeed(parseInt(speedButton.innerText, 10));
+    const curSpeed = parseInt(speedButton.innerText.at(-1), 10);
+    speedButton.innerText = `speed x${(curSpeed % 5) + 1}`;
+    gameManager.setLocalGameSpeed(parseInt(speedButton.innerText.at(-1), 10));
     gameManager.resetLocalGameInfo();
   });
 


### PR DESCRIPTION
<!-- PR Title은 [FEAT/FIX/STYLE/DOCS 등등] Title 형식으로 맞춰주세요 -->

<!-- PR 개요는 이슈링크로 대체합니다 -->
## ⭐️ 해당 이슈
- #230

<!-- 구현사항, 변경사항 등 자세히 적어주세요 -->
<!-- 화면 변경사항이 있다면 해당 화면 이미지도 추가해주시면 좋아요 -->
## 📜 작업 내용
- 로컬 게임 설정, 게임 후 모달 추가했습니다.
- 5점을 기준으로 잡았습니다.
- 모달에서는 점수는 안 보여주고 누가 이겼는지만 보여줍니다.
- 공 재질을 변경했습니다.
  - 공 색깔이 바뀌어도 바뀐 티가 별로 나질 않아서 단색으로 바꾸고, 반사도를 높인 재질로 수정했습니다.
- 로컬 게임 커스텀 세팅 시 게임이 일시정지 되고, 설정이 끝나고 다시 버튼 클릭 시 점수가 리셋된 상태에서 게임이 시작됩니다.
  - 렌더링을 일시정지 시키는 방식이라 로컬게임의 로직이 살짝 바뀌었습니다.
  - 로컬 게임 렌더링 시작, 스탑 메서드 추가됐습니다. 멀티게임은 그대로입니다.
  - 커스텀 버튼으로 세팅을 바꿔도 렌더링 된 이후부터 볼 수 있어서  게임을 다시 시작해야 바뀐 세팅이 화면에 보입니다.
- 로컬에서 속도가 높으면 가끔 벽에 공이 붙어가는 경우가 있어서 히트 범위 더 여유있게 수정했습니다.
<img width="1437" alt="스크린샷 2024-06-18 오후 6 32 34" src="https://github.com/Retro-pong/Transcendence/assets/100325940/df51b880-99ce-4b65-91e5-f40781432209">


<!-- 이 부분은 자세히 리뷰해줬으면 하는 부분이 있다면 적어주세요 -->
## 📍 리뷰 요구사항
- 
