### PR TITLE
[Feat] 멀티 게임 닉네임 설정

### DIFF
--- a/frontend/src/pages/game/PlayGame.js
+++ b/frontend/src/pages/game/PlayGame.js
@@ -25,6 +25,8 @@ class PlayGame extends PageComponent {
     this.gameEnd = false;
     this.gameError = false;
     this.gameErrorMsg = 'Game Error. Please try again later.';
+    this.redNick = '';
+    this.blueNick = '';
   }
 
   getGameManager() {
@@ -45,9 +47,13 @@ class PlayGame extends PageComponent {
       content: `
         <div class="d-flex flex-column justify-content-center align-items-center h-50">
           <div id="gameResult" class="fs-15"></div>
-          <div class="w-75 d-flex justify-content-around align-items-center fs-12">
-            <div id="redScore" class="text-danger"></div>
-            <div id="blueScore" class="text-primary"></div>
+          <div class="w-100 d-flex align-items-center">
+            <div id="modalRedNick" class="text-danger w-75 d-flex justify-content-center fs-9"></div>
+            <div id="redScore" class="text-danger w-25 d-flex fs-12"></div>
+          </div>          
+          <div class="w-100 d-flex align-items-center">
+            <div id="modalBlueNick" class="text-primary w-75 d-flex justify-content-center fs-9"></div>
+            <div id="blueScore" class="text-primary w-25 d-flex fs-12"></div>
           </div>
         </div>
       `,
@@ -60,8 +66,12 @@ class PlayGame extends PageComponent {
       Click Start !
       </button>
       <div id="scoreContainer"
-           class="position-absolute top-0 start-50 translate-middle-x w-40 px-3 text-white d-flex flex-column align-items-center border border-5 rounded">
-        <span class="fs-10">score</span>
+           class="position-absolute top-0 start-50 translate-middle-x px-3 w-40 text-white d-flex flex-column align-items-center border border-5 rounded">
+        <span class="fs-6">score</span>
+        <div class="d-flex w-100 fs-6">
+          <span id="player1Nick" class="w-50 d-flex justify-content-center text-danger">RED</span>
+          <span id="player2Nick" class="w-50 d-flex justify-content-center text-primary">BLUE</span>
+        </div>
         <div class="d-flex w-100 fs-8">
           <span id="player1Score" class="w-50 d-flex justify-content-center text-danger" data-score="0">0</span>
           <span id="player2Score" class="w-50 d-flex justify-content-center text-primary" data-score="0">0</span>
@@ -77,6 +87,8 @@ class PlayGame extends PageComponent {
     const gameResultModalElement = document.querySelector('#gameResultModal');
     const modalCloseBtn = document.querySelector('#gameResultBtn');
     const gameResult = document.querySelector('#gameResult');
+    const modalRedNick = document.querySelector('#modalRedNick');
+    const modalBlueNick = document.querySelector('#modalBlueNick');
     const redScore = document.querySelector('#redScore');
     const blueScore = document.querySelector('#blueScore');
     const gameStartBtn = document.querySelector('#gameStartBtn');
@@ -138,6 +150,12 @@ class PlayGame extends PageComponent {
               gameStartBtn.classList.add('d-none');
               gameStartBtn.disabled = false;
             }
+            if (!this.redNick || !this.blueNick) {
+              this.redNick = data.redNick;
+              this.blueNick = data.blueNick;
+              document.getElementById('player1Nick').innerText = this.redNick;
+              document.getElementById('player2Nick').innerText = this.blueNick;
+            }
             this.redScore = data.redScore;
             this.blueScore = data.blueScore;
             this.gameManger.multiGameUpdateObjects(data);
@@ -167,6 +185,8 @@ class PlayGame extends PageComponent {
           );
           Router.navigateTo('/game');
         } else {
+          modalRedNick.innerText = this.redNick;
+          modalBlueNick.innerText = this.blueNick;
           redScore.innerText = `${this.redScore}`;
           blueScore.innerText = `${this.blueScore}`;
           const winner = this.redScore > this.blueScore ? 'red' : 'blue';


### PR DESCRIPTION
<!-- PR Title은 [FEAT/FIX/STYLE/DOCS 등등] Title 형식으로 맞춰주세요 -->

<!-- PR 개요는 이슈링크로 대체합니다 -->
## ⭐️ 해당 이슈
- #239

<!-- 구현사항, 변경사항 등 자세히 적어주세요 -->
<!-- 화면 변경사항이 있다면 해당 화면 이미지도 추가해주시면 좋아요 -->
## 📜 작업 내용
- 멀티 게임 소켓에서 닉네임 받아서 화면에 세팅합니다.
- 결과 모달에서 닉네임 길이가 서로 다른 문제 때문에 점수를 세로로 배치했습니다.
<img width="1437" alt="스크린샷 2024-06-18 오후 7 20 54" src="https://github.com/Retro-pong/Transcendence/assets/100325940/080e6e82-196d-4822-9d11-4638a51cbbeb">


<!-- 이 부분은 자세히 리뷰해줬으면 하는 부분이 있다면 적어주세요 -->
## 📍 리뷰 요구사항
- 
