### PR TITLE
[Fix] 대기실 소켓 에러 처리

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,10 +2,12 @@ import drawBackground from '@/background/background.js';
 import TokenManager from '@/utils/TokenManager';
 import Fetch from '@/utils/Fetch';
 import Router from '@/utils/Router';
+import SocketManager from '@/utils/SocketManager';
 
 Fetch.init();
 
 window.addEventListener('popstate', Router.render);
+window.addEventListener('unload', SocketManager.setOffline);
 
 document.addEventListener('DOMContentLoaded', async () => {
   if (!TokenManager.getAccessToken() && TokenManager.getLoginStatus()) {

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -15,7 +15,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   Array.prototype.forEach.call(navigations, (nav) => {
     nav.addEventListener('click', async (e) => {
       e.preventDefault();
-      await Router.navigateTo(nav.href);
+      await Router.navigateTo(nav.pathname);
     });
   });
 

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,12 +2,10 @@ import drawBackground from '@/background/background.js';
 import TokenManager from '@/utils/TokenManager';
 import Fetch from '@/utils/Fetch';
 import Router from '@/utils/Router';
-import SocketManager from '@/utils/SocketManager';
 
 Fetch.init();
 
 window.addEventListener('popstate', Router.render);
-window.addEventListener('unload', SocketManager.setOffline);
 
 document.addEventListener('DOMContentLoaded', async () => {
   if (!TokenManager.getAccessToken() && TokenManager.getLoginStatus()) {

--- a/frontend/src/pages/game/CreateRoom.js
+++ b/frontend/src/pages/game/CreateRoom.js
@@ -71,7 +71,7 @@ class CreateRoom extends PageComponent {
         Router.navigateTo(`/game/waiting?id=${roomId}&mode=${gameMode}`);
       })
       .catch((err) => {
-        if (err.error === 'UNIQUE constraint failed: room.room_name') {
+        if (err.message === 'UNIQUE constraint failed: room.room_name') {
           ToastHandler.setToast('Room name already exists');
           this.titleState = false;
           this.progressBar();

--- a/frontend/src/pages/game/WaitingRoom.js
+++ b/frontend/src/pages/game/WaitingRoom.js
@@ -23,6 +23,7 @@ class WaitingRoom extends PageComponent {
       this.roomMode === 'normal'
         ? [{ id: 1 }, { id: 2 }]
         : [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+    window.addEventListener('popstate', this.onPopstate, { once: true });
   }
 
   async render() {

--- a/frontend/src/pages/game/WaitingRoom.js
+++ b/frontend/src/pages/game/WaitingRoom.js
@@ -5,7 +5,6 @@ import ModalComponent from '@component/modal/ModalComponent';
 import GameManual from '@component/contents/GameManual';
 import SocketManager from '@/utils/SocketManager';
 import Router from '@/utils/Router';
-import TokenManager from '@/utils/TokenManager';
 import ToastHandler from '@/utils/ToastHandler';
 
 class WaitingRoom extends PageComponent {
@@ -14,16 +13,11 @@ class WaitingRoom extends PageComponent {
     this.setTitle('Waiting Room');
     const params = new URLSearchParams(document.location.search);
     this.roomTitle = '';
-    this.roomId = params.get('id') || '';
-    this.roomMode = params.get('mode') || '';
-    SocketManager.roomSocket = SocketManager.createSocket(
-      `/${this.roomMode}_room/${this.roomId}/`
-    );
+    this.roomMode = params.get('mode');
     this.players =
       this.roomMode === 'normal'
         ? [{ id: 1 }, { id: 2 }]
         : [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
-    window.addEventListener('popstate', this.onPopstate, { once: true });
   }
 
   async render() {
@@ -93,25 +87,10 @@ class WaitingRoom extends PageComponent {
     this.players = players;
   }
 
-  onPopstate() {
-    if (!SocketManager.roomSocket) return;
-    ToastHandler.setToast('You left the room');
-    SocketManager.roomSocket.close();
-  }
-
   async afterRender() {
-    SocketManager.roomSocket.onopen = () => {
-      const message = {
-        type: 'access',
-        token: TokenManager.getAccessToken(),
-      };
-      SocketManager.roomSocket.send(JSON.stringify(message));
-      console.log('Room Socket Connected');
-    };
-
     SocketManager.roomSocket.onmessage = (e) => {
       const data = JSON.parse(e.data);
-      this.roomTitle = data.room_name || '';
+      this.roomTitle = data.room_name;
       this.addRoomTitle();
       switch (data.type) {
         case 'users':
@@ -124,26 +103,22 @@ class WaitingRoom extends PageComponent {
             `/game/play?id=${data.room_id}&mode=${this.roomMode}`
           );
           break;
-        case 'full':
-          ToastHandler.setToast('Room is full');
-          SocketManager.roomSocket.close(1011, 'Room is full');
+        case 'error':
+          console.error('Room Socket Error:', data.message);
+          ToastHandler.setToast(data.message);
+          SocketManager.roomSocket.close();
+          history.back();
           break;
         default:
+          // TODO: data 수정되면 조건문 삭제
+          if (data.error) {
+            console.error('Room Socket Error:', data.error);
+            ToastHandler.setToast(data.error);
+            SocketManager.roomSocket.close();
+            history.back();
+          }
           break;
       }
-    };
-
-    SocketManager.roomSocket.onclose = (e) => {
-      console.log(`Room Socket Disconnected (${e.code})`);
-      if (e.code !== 1000) {
-        Router.navigateTo('/game');
-      }
-      SocketManager.roomSocket = null;
-    };
-
-    SocketManager.roomSocket.onerror = (error) => {
-      ToastHandler.setToast('Cannot join the room');
-      console.error('Room Socket Error:', error);
     };
   }
 }

--- a/frontend/src/pages/game/WaitingRoom.js
+++ b/frontend/src/pages/game/WaitingRoom.js
@@ -126,8 +126,7 @@ class WaitingRoom extends PageComponent {
           break;
         case 'full':
           ToastHandler.setToast('Room is full');
-          SocketManager.roomSocket.close();
-          Router.navigateTo('/game/join');
+          SocketManager.roomSocket.close(1011, 'Room is full');
           break;
         default:
           break;
@@ -137,14 +136,13 @@ class WaitingRoom extends PageComponent {
     SocketManager.roomSocket.onclose = (e) => {
       console.log(`Room Socket Disconnected (${e.code})`);
       if (e.code !== 1000) {
-        Router.navigateTo('/game/join');
+        Router.navigateTo('/game');
       }
       SocketManager.roomSocket = null;
     };
 
     SocketManager.roomSocket.onerror = (error) => {
       ToastHandler.setToast('Cannot join the room');
-      Router.navigateTo('/game/join');
       console.error('Room Socket Error:', error);
     };
   }

--- a/frontend/src/utils/Router.js
+++ b/frontend/src/utils/Router.js
@@ -22,7 +22,6 @@ class Router {
     '/game/waiting': WaitingRoom,
     '/game/play': PlayGame,
     '/friends': Friends,
-    '/404': Home, // TODO: NotFound 추가
   };
 
   static before = null;
@@ -103,7 +102,8 @@ class Router {
     const isLoggedIn = TokenManager.getLoginStatus();
 
     if (!(currPathname in Router.routes)) {
-      Router.replaceState('/404');
+      ToastHandler.setToast('Page not found! [404]');
+      Router.replaceState(Router.getCurrentPage() || '/');
     } else if (currPathname === '/login' && isLoggedIn) {
       ToastHandler.setToast('You are already logged in!');
       const beforePage = Router.getCurrentPage() || '/';

--- a/frontend/src/utils/Router.js
+++ b/frontend/src/utils/Router.js
@@ -94,6 +94,7 @@ class Router {
 
   static onRefresh(event) {
     event.preventDefault();
+    ToastHandler.setToast('Refreshing is not allowed here!');
   }
 
   static async render() {
@@ -113,6 +114,8 @@ class Router {
       }
     } else if (currPathname !== '/login' && !isLoggedIn) {
       Router.replaceState('/login');
+    } else if (currPathname === '/game/waiting') {
+      SocketManager.setRoomSocket();
     } else {
       Router.setPageHistory(currPathname);
     }

--- a/frontend/src/utils/Router.js
+++ b/frontend/src/utils/Router.js
@@ -33,8 +33,7 @@ class Router {
   static navBar = document.getElementById('navBar');
 
   static async navigateTo(url) {
-    SocketManager.closeSockets();
-    if (url === window.location.href) {
+    if (url === Router.getPageHistory()) {
       Router.replaceState(url);
     } else {
       Router.pushState(url);

--- a/frontend/src/utils/Router.js
+++ b/frontend/src/utils/Router.js
@@ -34,6 +34,7 @@ class Router {
   static navBar = document.getElementById('navBar');
 
   static async navigateTo(url) {
+    SocketManager.closeSockets();
     if (url === window.location.href) {
       Router.replaceState(url);
     } else {

--- a/frontend/src/utils/Router.js
+++ b/frontend/src/utils/Router.js
@@ -34,8 +34,11 @@ class Router {
   static navBar = document.getElementById('navBar');
 
   static async navigateTo(url) {
-    if (url === window.location.href) return;
-    Router.pushState(url);
+    if (url === window.location.href) {
+      Router.replaceState(url);
+    } else {
+      Router.pushState(url);
+    }
     await Router.render();
   }
 

--- a/frontend/src/utils/Router.js
+++ b/frontend/src/utils/Router.js
@@ -44,11 +44,11 @@ class Router {
   }
 
   static pushState(url) {
-    history.pushState(null, null, url);
+    history.pushState(null, '', url);
   }
 
   static replaceState(url) {
-    history.replaceState(null, null, url);
+    history.replaceState(null, '', url);
   }
 
   static getCurrentPage() {
@@ -99,17 +99,17 @@ class Router {
     const isLoggedIn = TokenManager.getLoginStatus();
 
     if (!(currPathname in Router.routes)) {
-      Router.pushState('/404');
+      Router.replaceState('/404');
     } else if (currPathname === '/login' && isLoggedIn) {
       ToastHandler.setToast('You are already logged in!');
-      const beforePage = Router.getCurrentPage();
+      const beforePage = Router.getCurrentPage() || '/';
       if (beforePage === '/login') {
-        Router.pushState('/');
+        Router.replaceState('/');
       } else {
-        Router.pushState(beforePage);
+        Router.replaceState(beforePage);
       }
     } else if (currPathname !== '/login' && !isLoggedIn) {
-      Router.pushState('/login');
+      Router.replaceState('/login');
     } else {
       Router.setCurrentPage(currPathname);
     }

--- a/frontend/src/utils/Router.js
+++ b/frontend/src/utils/Router.js
@@ -54,11 +54,11 @@ class Router {
     history.replaceState(null, '', url);
   }
 
-  static getCurrentPage() {
-    return sessionStorage.getItem('curPage');
+  static getPageHistory() {
+    return sessionStorage.getItem('curPage') || '/';
   }
 
-  static setCurrentPage(path) {
+  static setPageHistory(path) {
     sessionStorage.setItem('curPage', path);
   }
 
@@ -103,10 +103,10 @@ class Router {
 
     if (!(currPathname in Router.routes)) {
       ToastHandler.setToast('Page not found! [404]');
-      Router.replaceState(Router.getCurrentPage() || '/');
+      Router.replaceState(Router.getPageHistory());
     } else if (currPathname === '/login' && isLoggedIn) {
       ToastHandler.setToast('You are already logged in!');
-      const beforePage = Router.getCurrentPage() || '/';
+      const beforePage = Router.getPageHistory();
       if (beforePage === '/login') {
         Router.replaceState('/');
       } else {
@@ -115,7 +115,7 @@ class Router {
     } else if (currPathname !== '/login' && !isLoggedIn) {
       Router.replaceState('/login');
     } else {
-      Router.setCurrentPage(currPathname);
+      Router.setPageHistory(currPathname);
     }
     // TODO: 게임방 페이지에서 뒤로가기 제한
     // else if (currPathname === '/game') {

--- a/frontend/src/utils/Router.js
+++ b/frontend/src/utils/Router.js
@@ -127,7 +127,6 @@ class Router {
     } else if (Router.getPathname() === '/game/waiting') {
       Router.hideElement(Router.navBar);
       window.addEventListener('beforeunload', Router.onRefresh);
-      window.addEventListener('popstate', page.onPopstate);
     } else {
       if (
         Router.before &&
@@ -139,14 +138,7 @@ class Router {
         }
         Router.before.setDisposeAll();
       }
-      if (
-        Router.before &&
-        (Router.before.pathname === '/game/waiting' ||
-          Router.before.pathname === '/game/play')
-      ) {
-        window.removeEventListener('popstate', Router.before.onPopstate);
-        window.removeEventListener('beforeunload', Router.onRefresh);
-      }
+      window.removeEventListener('beforeunload', Router.onRefresh);
       Router.showElement(Router.background);
       Router.resetPageApp();
       if (Router.getPathname() !== '/login') {

--- a/frontend/src/utils/SocketManager.js
+++ b/frontend/src/utils/SocketManager.js
@@ -9,36 +9,44 @@ class SocketManager {
 
   static gameSocket = null;
 
+  static getAccessMessage() {
+    const message = {
+      type: 'access',
+      token: TokenManager.getAccessToken(),
+    };
+    return JSON.stringify(message);
+  }
+
   static createSocket(url) {
     return new WebSocket(`${this.#BASE_URL}${url}`);
   }
 
   static closeRoomSocket() {
-    if (SocketManager.roomSocket) {
-      SocketManager.roomSocket.close();
-      SocketManager.roomSocket = null;
+    if (this.roomSocket) {
+      this.roomSocket.close();
+      this.roomSocket = null;
     }
   }
 
   static closeGameSocket() {
-    if (SocketManager.gameSocket) {
-      SocketManager.gameSocket.close();
-      SocketManager.gameSocket = null;
+    if (this.gameSocket) {
+      this.gameSocket.close();
+      this.gameSocket = null;
     }
   }
 
   static closeSockets() {
-    SocketManager.closeRoomSocket();
-    SocketManager.closeGameSocket();
+    this.closeRoomSocket();
+    this.closeGameSocket();
   }
 
   static setOffline() {
-    SocketManager.closeSockets();
-    if (!SocketManager.onlineSocket) {
+    this.closeSockets();
+    if (!this.onlineSocket) {
       return;
     }
-    SocketManager.onlineSocket.close();
-    SocketManager.onlineSocket = null;
+    this.onlineSocket.close();
+    this.onlineSocket = null;
   }
 
   static setOnline() {
@@ -49,11 +57,7 @@ class SocketManager {
       this.onlineSocket = this.createSocket('/login/');
     }
     this.onlineSocket.onopen = () => {
-      const message = {
-        type: 'access',
-        token: TokenManager.getAccessToken(),
-      };
-      this.onlineSocket.send(JSON.stringify(message));
+      this.onlineSocket.send(this.getAccessMessage());
       console.log('Online Socket Connected');
     };
     this.onlineSocket.onmessage = (e) => {

--- a/frontend/src/utils/SocketManager.js
+++ b/frontend/src/utils/SocketManager.js
@@ -13,7 +13,27 @@ class SocketManager {
     return new WebSocket(`${this.#BASE_URL}${url}`);
   }
 
+  static closeRoomSocket() {
+    if (SocketManager.roomSocket) {
+      SocketManager.roomSocket.close();
+      SocketManager.roomSocket = null;
+    }
+  }
+
+  static closeGameSocket() {
+    if (SocketManager.gameSocket) {
+      SocketManager.gameSocket.close();
+      SocketManager.gameSocket = null;
+    }
+  }
+
+  static closeSockets() {
+    SocketManager.closeRoomSocket();
+    SocketManager.closeGameSocket();
+  }
+
   static setOffline() {
+    SocketManager.closeSockets();
     if (!SocketManager.onlineSocket) {
       return;
     }


### PR DESCRIPTION
<!-- PR Title은 [FEAT/FIX/STYLE/DOCS 등등] Title 형식으로 맞춰주세요 -->

<!-- PR 개요는 이슈링크로 대체합니다 -->
## ⭐️ 해당 이슈
- #237 

<!-- 구현사항, 변경사항 등 자세히 적어주세요 -->
<!-- 화면 변경사항이 있다면 해당 화면 이미지도 추가해주시면 좋아요 -->
## 📜 작업 내용
### 대기실 소켓, SocketManager
- 대기실 소켓 에러를 라우터에서 관리하기 위해 onmessage 제외한 나머지 리스너를 SocketManager로 분리했습니다
- 대기실 페이지는 세션스토리지에 저장하지 않도록 했습니다
- popstate에 once 옵션 줘서 한번만 실행하고 제거되도록 수정했습니다
- 룸소켓, 게임 소켓 닫는 메소드 추가했습니다

### Router
- curPage 저장, 반환하는 메소드명이 헷갈려서 수정했습니다
- 네비게이션 시 url을 href에서 pathname으로 통일했습니다
- 404일 때 토스트 띄우고 replaceState 해주었습니다 

<!-- 이 부분은 자세히 리뷰해줬으면 하는 부분이 있다면 적어주세요 -->
## 📍 리뷰 요구사항
- 앞,뒤로 가기 꼬일 때가 있어서 pushState 대신 replaceState으로 수정해봤는데 별 차이는 없네요.. 테스트 더 필요할 거 같습니다

