### PR TITLE
[Fix] 게임 소켓 토너먼트 부분 수정

### DIFF
--- a/frontend/src/component/modal/ModalComponent.js
+++ b/frontend/src/component/modal/ModalComponent.js
@@ -29,7 +29,7 @@ const ModalComponent = ({
         <div class="modal-body">
           ${content}
         </div>
-          <div class="modal-footer border-0 bg-black rounded-bottom-5 border-0 d-flex justify-content-center align-items-center">
+          <div class="modal-footer border-0 bg-black rounded-bottom-5 d-flex justify-content-center align-items-center">
             ${buttonList.map((type) => buttons[type]).join('')}
           </div>
         </div>

--- a/frontend/src/pages/game/PlayGame.js
+++ b/frontend/src/pages/game/PlayGame.js
@@ -123,10 +123,10 @@ class PlayGame extends PageComponent {
 
     const setGameResultModal = () => {
       const winner = this.redScore > this.blueScore ? 'red' : 'blue';
-      modalRedNick.innerText = this.redNick;
-      modalBlueNick.innerText = this.blueNick;
-      redScore.innerText = this.gameEnd ? `${this.redScore}` : '';
-      blueScore.innerText = this.gameEnd ? `${this.blueScore}` : '';
+      modalRedNick.innerText = this.gameEnd ? this.redNick : '';
+      modalBlueNick.innerText = this.gameEnd ? this.blueNick : '';
+      redScore.innerText = this.gameEnd ? this.redScore : '';
+      blueScore.innerText = this.gameEnd ? this.blueScore : '';
       if (this.gameEnd) {
         gameResult.innerText = this.side === winner ? 'You Win!' : 'You Lose!';
       } else {

--- a/frontend/src/pages/game/PlayGame.js
+++ b/frontend/src/pages/game/PlayGame.js
@@ -6,6 +6,7 @@ import TokenManager from '@/utils/TokenManager';
 import GameManager from '@/utils/game/GameManager';
 import Router from '@/utils/Router';
 import ToastHandler from '@/utils/ToastHandler';
+import Fetch from '@/utils/Fetch';
 
 class PlayGame extends PageComponent {
   constructor() {
@@ -202,16 +203,15 @@ class PlayGame extends PageComponent {
             console.log('result', data);
             this.gameEnd = data.winner !== 'None';
             if (this.gameMode === 'semi-final') {
-              // Fetch.showLoading();
+              Fetch.showLoading();
             } else {
               SocketManager.gameSocket.close(1000, 'Game End');
             }
             break;
           case 'final':
             console.log('final', data);
-            // Fetch.hideLoading();
-            this.gameEnd = data.isFinal === 'True';
-            this.isFinalUser = data.isFinalUser === 'True';
+            this.gameEnd = data.isFinal === true;
+            this.isFinalUser = data.isFinalUser === true;
             SocketManager.gameSocket.close(1000, 'Game End');
             break;
           case 'exit':
@@ -230,7 +230,6 @@ class PlayGame extends PageComponent {
       };
       SocketManager.gameSocket.onclose = async (e) => {
         console.log('game socket closed', e.code);
-
         if (this.gameEnd === false) {
           ToastHandler.setToast(
             this.gameError ? this.gameErrorMsg : 'User Exit'
@@ -239,7 +238,6 @@ class PlayGame extends PageComponent {
         setGameResultModal();
         gameResultModal.show();
         SocketManager.gameSocket = null;
-        await Router.navigateTo('/game');
       };
       SocketManager.gameSocket.onerror = () => {
         ToastHandler.setToast('Game Error! Please try again later');

--- a/frontend/src/pages/game/PlayGame.js
+++ b/frontend/src/pages/game/PlayGame.js
@@ -89,6 +89,9 @@ class PlayGame extends PageComponent {
       <button id="gameStartBtn" class="btn btn-outline-light position-absolute w-50 h-25 top-50 start-50 translate-middle fs-15 d-none rounded">
       Click Start !
       </button>
+      <div id="gameWaitingText" class="position-absolute w-50 h-25 top-50 start-50 translate-middle fs-15 text-center rounded d-none">
+      Waiting for opponent...
+      </div>
       <div id="scoreContainer"
            class="position-absolute top-0 start-50 translate-middle-x px-3 w-40 text-white d-flex flex-column align-items-center border border-5 rounded">
         <span class="fs-6">score</span>
@@ -116,6 +119,7 @@ class PlayGame extends PageComponent {
     const redScore = document.querySelector('#redScore');
     const blueScore = document.querySelector('#blueScore');
     const gameStartBtn = document.querySelector('#gameStartBtn');
+    const gameWaitingText = document.querySelector('#gameWaitingText');
 
     modalCloseBtn.addEventListener('click', async () => {
       gameResultModal.hide();
@@ -147,8 +151,9 @@ class PlayGame extends PageComponent {
     });
 
     gameStartBtn.addEventListener('click', () => {
-      gameStartBtn.innerText = 'Waiting for opponent...';
       gameStartBtn.disabled = true;
+      gameStartBtn.classList.add('d-none');
+      gameWaitingText.classList.remove('d-none');
       SocketManager.gameSocket.send(JSON.stringify({ type: 'ready' }));
     });
 
@@ -179,15 +184,13 @@ class PlayGame extends PageComponent {
             gameStartBtn.classList.remove('d-none');
             gameStartBtn.disabled = false;
             this.gameStart = false;
-            gameResult.innerText = '';
             break;
           case 'render':
             if (this.gameStart === false) {
               this.gameStart = true;
               this.gameEnd = false;
               this.gameError = false;
-              gameStartBtn.classList.add('d-none');
-              gameStartBtn.disabled = false;
+              gameWaitingText.classList.add('d-none');
             }
             if (!this.redNick || !this.blueNick) {
               this.redNick = data.redNick;
@@ -203,7 +206,7 @@ class PlayGame extends PageComponent {
             console.log('result', data);
             this.gameEnd = data.winner !== 'None';
             if (this.gameMode === 'semi-final') {
-              Fetch.showLoading();
+
             } else {
               SocketManager.gameSocket.close(1000, 'Game End');
             }

--- a/frontend/src/pages/game/PlayGame.js
+++ b/frontend/src/pages/game/PlayGame.js
@@ -70,14 +70,14 @@ class PlayGame extends PageComponent {
       modalId: 'gameResultModal',
       content: `
         <div class="d-flex flex-column justify-content-center align-items-center h-50">
-          <div id="gameResult" class="fs-15 w-100 d-flex justify-content-center align-items-center"></div>
-          <div class="w-100 d-flex align-items-center">
-            <div id="modalRedNick" class="text-danger w-75 d-flex justify-content-center fs-9"></div>
-            <div id="redScore" class="text-danger w-25 d-flex fs-12"></div>
+          <div id="gameResult" class="fs-15 w-100 text-center"></div>
+          <div class="w-100 d-flex justify-content-center align-items-center">
+            <div id="modalRedNick" class="text-danger w-25 fs-12"></div>
+            <div id="redScore" class="text-danger w-25 text-end fs-12"></div>
           </div>          
-          <div class="w-100 d-flex align-items-center">
-            <div id="modalBlueNick" class="text-primary w-75 d-flex justify-content-center fs-9"></div>
-            <div id="blueScore" class="text-primary w-25 d-flex fs-12"></div>
+          <div class="w-100 d-flex justify-content-center align-items-center">
+            <div id="modalBlueNick" class="text-primary w-25 fs-12"></div>
+            <div id="blueScore" class="text-primary w-25 text-end fs-12"></div>
           </div>
         </div>
       `,
@@ -130,7 +130,7 @@ class PlayGame extends PageComponent {
       if (this.gameEnd) {
         gameResult.innerText = this.side === winner ? 'You Win!' : 'You Lose!';
       } else {
-        gameResult.innerText = 'Game End! User Disconnected!';
+        gameResult.innerText = 'Game End!\nUser Disconnected!';
       }
       gameResult.classList.add(
         this.side === 'red' ? 'text-danger' : 'text-primary'

--- a/frontend/src/pages/game/PlayGame.js
+++ b/frontend/src/pages/game/PlayGame.js
@@ -6,7 +6,6 @@ import TokenManager from '@/utils/TokenManager';
 import GameManager from '@/utils/game/GameManager';
 import Router from '@/utils/Router';
 import ToastHandler from '@/utils/ToastHandler';
-import Fetch from '@/utils/Fetch';
 
 class PlayGame extends PageComponent {
   constructor() {
@@ -70,14 +69,18 @@ class PlayGame extends PageComponent {
       modalId: 'gameResultModal',
       content: `
         <div class="d-flex flex-column justify-content-center align-items-center h-50">
-          <div id="gameResult" class="fs-15 w-100 text-center"></div>
-          <div class="w-100 d-flex justify-content-center align-items-center">
+          <div id="gameResult" class="fs-15 w-100 text-center">
+          </div>
+           <div id="finalText" class="fs-13 w-100 text-center text-success d-none">
+              You have<br/>Final Game!
+           </div>
+          <div class="w-75 d-flex justify-content-between align-items-center">
             <div id="modalRedNick" class="text-danger w-25 fs-12"></div>
-            <div id="redScore" class="text-danger w-25 text-end fs-12"></div>
+            <div id="redScore" class="text-danger w-25 text-end fs-13"></div>
           </div>          
-          <div class="w-100 d-flex justify-content-center align-items-center">
+          <div class="w-75 d-flex justify-content-between align-items-center">
             <div id="modalBlueNick" class="text-primary w-25 fs-12"></div>
-            <div id="blueScore" class="text-primary w-25 text-end fs-12"></div>
+            <div id="blueScore" class="text-primary w-25 text-end fs-13"></div>
           </div>
         </div>
       `,
@@ -114,6 +117,7 @@ class PlayGame extends PageComponent {
     const gameResultModalElement = document.querySelector('#gameResultModal');
     const modalCloseBtn = document.querySelector('#gameResultBtn');
     const gameResult = document.querySelector('#gameResult');
+    const finalText = document.querySelector('#finalText');
     const modalRedNick = document.querySelector('#modalRedNick');
     const modalBlueNick = document.querySelector('#modalBlueNick');
     const redScore = document.querySelector('#redScore');
@@ -133,6 +137,9 @@ class PlayGame extends PageComponent {
       blueScore.innerText = this.gameEnd ? this.blueScore : '';
       if (this.gameEnd) {
         gameResult.innerText = this.side === winner ? 'You Win!' : 'You Lose!';
+        if (this.isFinalUser) {
+          finalText.classList.remove('d-none');
+        }
       } else {
         gameResult.innerText = 'Game End!\nUser Disconnected!';
       }
@@ -206,13 +213,15 @@ class PlayGame extends PageComponent {
             console.log('result', data);
             this.gameEnd = data.winner !== 'None';
             if (this.gameMode === 'semi-final') {
-
+              gameWaitingText.innerText = 'Waiting for other players...';
+              gameWaitingText.classList.remove('d-none');
             } else {
               SocketManager.gameSocket.close(1000, 'Game End');
             }
             break;
           case 'final':
             console.log('final', data);
+            gameWaitingText.classList.add('d-none');
             this.gameEnd = data.isFinal === true;
             this.isFinalUser = data.isFinalUser === true;
             SocketManager.gameSocket.close(1000, 'Game End');


### PR DESCRIPTION
<!-- PR Title은 [FEAT/FIX/STYLE/DOCS 등등] Title 형식으로 맞춰주세요 -->

<!-- PR 개요는 이슈링크로 대체합니다 -->
## ⭐️ 해당 이슈
- #273

<!-- 구현사항, 변경사항 등 자세히 적어주세요 -->
<!-- 화면 변경사항이 있다면 해당 화면 이미지도 추가해주시면 좋아요 -->
## 📜 작업 내용
- 토너먼트에서 문구가 제대로 뜨지 않던 문제는 data의 bool 값 체크를 잘못하고 있었습니다...
  - true인데 True로 체크했습니다...
  - JSON.parse 하면 문자열로 받은 데이터도 알아서 bool 값으로 바꿔주는데 문자열로 체크하고 있었습니다...
- 토너먼트 결과창에서 결승전이 있는 사람에게는 `You have Final Game!` 문구를 추가했습니다.
- 토너먼트에서 한쪽이 먼저 끝났을 때 WaitingText를 띄워주고 대기합니다.
  - 토너먼트와 게임 시작 버튼 클릭 시 WaitingText를 같이 사용하기 위해 처음 시작 버튼의 innerText를 Waiting 문구로 바꾸던 방식에서, WaitingText 엘리먼트를 분리해서 해당 엘리먼트를 d-none, display 하는 방식으로 수정했습니다.
- 결과창에서 disconnect 문구를 가운데 정렬했습니다.
- 토너먼트에서 중간에 누가 나가지 않는 이상 문제 없이 작동하는 것 같습니다. 예외사항들은 같이 테스트 해보면서 찾아봐야 할 것 같습니다.
<img width="1437" alt="스크린샷 2024-06-26 오전 8 27 00" src="https://github.com/Retro-pong/Transcendence/assets/100325940/31bb76cc-9d89-4ec4-ac97-2064db1dbf15">
<img width="1437" alt="스크린샷 2024-06-26 오전 8 27 16" src="https://github.com/Retro-pong/Transcendence/assets/100325940/5d872f6b-fc8b-4b90-959c-cc10e2fd32ec">

<img width="1437" alt="스크린샷 2024-06-26 오전 8 30 13" src="https://github.com/Retro-pong/Transcendence/assets/100325940/f18be7dd-d5fe-483e-8613-b5c2124fdb44">


<!-- 이 부분은 자세히 리뷰해줬으면 하는 부분이 있다면 적어주세요 -->
## 📍 리뷰 요구사항

