### PR TITLE
[Fix] 로컬플레이 에러 수정

### DIFF
--- a/frontend/src/utils/Router.js
+++ b/frontend/src/utils/Router.js
@@ -156,6 +156,8 @@ class Router {
     Array.prototype.forEach.call(backDrop, (back) => {
       back.remove();
     });
+    document.body.className = '';
+    document.body.style = '';
 
     Router.app.innerHTML = await page.render();
     await page.afterRender();

--- a/frontend/src/utils/Router.js
+++ b/frontend/src/utils/Router.js
@@ -152,6 +152,11 @@ class Router {
       }
     }
 
+    const backDrop = document.getElementsByClassName('modal-backdrop');
+    Array.prototype.forEach.call(backDrop, (back) => {
+      back.remove();
+    });
+
     Router.app.innerHTML = await page.render();
     await page.afterRender();
     Router.before = page;

--- a/frontend/src/utils/Router.js
+++ b/frontend/src/utils/Router.js
@@ -139,9 +139,7 @@ class Router {
         typeof Router.before.getGameManager === 'function' &&
         Router.before.getGameManager()
       ) {
-        if (SocketManager.gameSocket) {
-          SocketManager.gameSocket.close();
-        }
+        SocketManager.closeGameSocket();
         Router.before.setDisposeAll();
       }
       window.removeEventListener('beforeunload', Router.onRefresh);

--- a/frontend/src/utils/SocketManager.js
+++ b/frontend/src/utils/SocketManager.js
@@ -46,7 +46,11 @@ class SocketManager {
     console.log('popstateEvent', mode);
     return async () => {
       const socket = mode === 'room' ? this.roomSocket : this.gameSocket;
-      if (!socket || socket.readyState === WebSocket.CLOSING) return;
+      if (!socket || socket.readyState === WebSocket.CLOSING) {
+        // 로컬 게임 뒤로가기
+        await Router.navigateTo('/game');
+        return;
+      }
       ToastHandler.setToast('You left the game');
       socket.close();
     };

--- a/frontend/src/utils/SocketManager.js
+++ b/frontend/src/utils/SocketManager.js
@@ -48,6 +48,7 @@ class SocketManager {
       const socket = mode === 'room' ? this.roomSocket : this.gameSocket;
       if (!socket || socket.readyState === WebSocket.CLOSING) {
         // 로컬 게임 뒤로가기
+        Router.replaceState('/game');
         await Router.navigateTo('/game');
         return;
       }

--- a/frontend/src/utils/game/GameManager.js
+++ b/frontend/src/utils/game/GameManager.js
@@ -199,8 +199,23 @@ class GameManager {
 
   localStartRendering() {
     if (!this.isRendering) {
-      this.isRendering = true;
-      this.localGameRender();
+      const gameWaitingText = document.querySelector('#gameWaitingText');
+      gameWaitingText.innerText = '3';
+      gameWaitingText.classList.remove('d-none');
+      setTimeout(() => {
+        gameWaitingText.innerText = '2';
+      }, 1000);
+      setTimeout(() => {
+        gameWaitingText.innerText = '1';
+      }, 2000);
+      setTimeout(() => {
+        gameWaitingText.innerText = 'Start!';
+      }, 3000);
+      setTimeout(() => {
+        gameWaitingText.classList.add('d-none');
+        this.isRendering = true;
+        this.localGameRender();
+      }, 4000);
     }
   }
 

--- a/frontend/src/utils/game/GameManager.js
+++ b/frontend/src/utils/game/GameManager.js
@@ -198,8 +198,8 @@ class GameManager {
   }
 
   localStartRendering() {
+    const gameWaitingText = document.querySelector('#gameWaitingText');
     if (!this.isRendering) {
-      const gameWaitingText = document.querySelector('#gameWaitingText');
       gameWaitingText.innerText = '3';
       gameWaitingText.classList.remove('d-none');
       setTimeout(() => {
@@ -213,6 +213,7 @@ class GameManager {
       }, 3000);
       setTimeout(() => {
         gameWaitingText.classList.add('d-none');
+        this.canvas.focus();
         this.isRendering = true;
         this.localGameRender();
       }, 4000);

--- a/frontend/src/utils/game/GameManager.js
+++ b/frontend/src/utils/game/GameManager.js
@@ -56,6 +56,12 @@ class GameManager {
     this.isRendering = false;
 
     this.localGameSpped = 3;
+    this.localTextTimeOut = {
+      1: null,
+      2: null,
+      3: null,
+      4: null,
+    };
   }
 
   disposeAll() {
@@ -197,21 +203,28 @@ class GameManager {
     }
   }
 
+  resetLocalTextTimeOut() {
+    Object.values(this.localTextTimeOut).forEach((timeout) => {
+      clearTimeout(timeout);
+    });
+  }
+
   localStartRendering() {
     const gameWaitingText = document.querySelector('#gameWaitingText');
     if (!this.isRendering) {
+      this.resetLocalTextTimeOut();
       gameWaitingText.innerText = '3';
       gameWaitingText.classList.remove('d-none');
-      setTimeout(() => {
+      this.localTextTimeOut[1] = setTimeout(() => {
         gameWaitingText.innerText = '2';
       }, 1000);
-      setTimeout(() => {
+      this.localTextTimeOut[2] = setTimeout(() => {
         gameWaitingText.innerText = '1';
       }, 2000);
-      setTimeout(() => {
+      this.localTextTimeOut[3] = setTimeout(() => {
         gameWaitingText.innerText = 'Start!';
       }, 3000);
-      setTimeout(() => {
+      this.localTextTimeOut[4] = setTimeout(() => {
         gameWaitingText.classList.add('d-none');
         this.canvas.focus();
         this.isRendering = true;

--- a/frontend/src/utils/game/localGame.js
+++ b/frontend/src/utils/game/localGame.js
@@ -77,19 +77,19 @@ function localGame(scene, objects, localGameInfo, gameSpeed, renderRequestId) {
       }
 
       // 벽에 부딪히면 방향 바꾸기
-      if (objects.ball.position.z < -6.8 && objects.ball.position.z > -8.2) {
+      if (objects.ball.position.z < -7.2 && objects.ball.position.z > -7.8) {
         newLocalGameInfo.c *= -1;
         newLocalGameInfo.hitStatus.leftWallHit = 1;
       }
-      if (objects.ball.position.z > 6.8 && objects.ball.position.z < 8.2) {
+      if (objects.ball.position.z > 7.2 && objects.ball.position.z < 7.8) {
         newLocalGameInfo.c *= -1;
         newLocalGameInfo.hitStatus.rightWallHit = 1;
       }
-      if (objects.ball.position.y > 4.2 && objects.ball.position.y < 5.7) {
+      if (objects.ball.position.y > 4.7 && objects.ball.position.y < 5.3) {
         newLocalGameInfo.b *= -1;
         newLocalGameInfo.hitStatus.topWallHit = 1;
       }
-      if (objects.ball.position.y < -4.2 && objects.ball.position.y > -5.7) {
+      if (objects.ball.position.y < -4.7 && objects.ball.position.y > -5.3) {
         newLocalGameInfo.b *= -1;
         newLocalGameInfo.hitStatus.bottomWallHit = 1;
       }


### PR DESCRIPTION
<!-- PR Title은 [FEAT/FIX/STYLE/DOCS 등등] Title 형식으로 맞춰주세요 -->

<!-- PR 개요는 이슈링크로 대체합니다 -->
## ⭐️ 해당 이슈
- #294 

<!-- 구현사항, 변경사항 등 자세히 적어주세요 -->
<!-- 화면 변경사항이 있다면 해당 화면 이미지도 추가해주시면 좋아요 -->
## 📜 작업 내용
### 로컬플레이 시작 전 3 2 1 Start 문구를 추가했습니다. 세팅 후에 다시 시작할 때도 똑같이 나옵니다.
- 처음 시작 시 배경이 까맣게 보이는건 배경 로드되는게 비동기로 작동해서 그런 것 같습니다.
### 로컬 플레이 popstate 이벤트도 SocketManager popstateEvent에 추가했습니다.
### 모달이 켜진 상태에서 뒤로가기 시 백드롭만 남아있는 현상이 로컬 게임뿐만 아니라 모든 모달에서 발생하고 있었습니다.(프로필, 친구)
- 모달이 켜지면 modal-backdrop이란 엘리먼트가 html 끝에 추가되는 방식이라 Router에서 페이지 내용을 render하기 직전에 모든 백드롭을 찾아서 없애주는 부분을 추가했습니다.
### 로컬게임에서 가끔 벽에 붙어가는 경우 있어서 범위 수정했습니다.
<img width="1439" alt="스크린샷 2024-06-29 오후 4 59 23" src="https://github.com/Retro-pong/Transcendence/assets/100325940/601fd329-9697-41d5-9112-cd1283435cd6">
<img width="1439" alt="스크린샷 2024-06-29 오후 4 59 30" src="https://github.com/Retro-pong/Transcendence/assets/100325940/b118700b-a449-485a-8bed-f531e72a0d5c">


<!-- 이 부분은 자세히 리뷰해줬으면 하는 부분이 있다면 적어주세요 -->
## 📍 리뷰 요구사항
- 
