### PR TITLE
[Design] 친구 검색 목록 css 수정

### DIFF
--- a/frontend/src/component/contents/FriendSearch.js
+++ b/frontend/src/component/contents/FriendSearch.js
@@ -1,11 +1,11 @@
 const FriendSearch = () => {
   return `
-    <div class="container px-5">
-      <div class="row px-3 border border-9 border-light rounded">
-        <span class="col-2 fs-8">-></span>
+    <div class="container px-5 w-100 h-100 d-flex flex-column align-items-center">
+      <div class="row w-100 h-25 px-3 border border-9 border-light rounded">
+        <span class="col-2 fs-8 text-center">-></span>
         <input id="searchFriend" type="text" class="col-10 text-light bg-transparent fs-8 border-0 px-5"/>
       </div>
-      <div id="friendSearchListContainer" class="row vh-50 overflow-y-scroll my-5 px-5 py-3 border border-9 border-light rounded">
+      <div id="friendSearchListContainer" class="row row-cols-1 d-flex flex-column flex-nowrap w-100 vh-50 overflow-y-scroll my-5 px-3 py-3 border border-9 border-light rounded">
       </div>
     </div>
   `;

--- a/frontend/src/component/contents/FriendSearchListItem.js
+++ b/frontend/src/component/contents/FriendSearchListItem.js
@@ -1,8 +1,8 @@
 const FriendSearchListItem = ({ nick }) => {
   return `
-  <div class="row my-2 px-5 h-25 d-flex justify-content-center align-items-center">
-    <div class="col-10 fs-10">${nick}</div>
-    <button class="col-2 friend-request-btn btn btn-no-outline-hover bg-transparent fs-8" data-nick=${nick}>+</button>
+  <div class="row my-2 px-4 d-flex justify-content-center align-items-center">
+    <div class="col-10 fs-10 text-wrap text-break" data-add-btn-target=${nick}>${nick}</div>
+    <button class="col-2 friend-request-btn btn btn-no-outline-hover fs-8" data-nick=${nick}>+</button>
   </div>
   `;
 };

--- a/frontend/src/pages/Friends.js
+++ b/frontend/src/pages/Friends.js
@@ -133,6 +133,18 @@ class Friends extends PageComponent {
             );
           });
       });
+      btn.addEventListener('mouseover', (e) => {
+        const friendName = e.target.dataset.nick;
+        document
+          .querySelector(`[data-add-btn-target="${friendName}"]`)
+          .classList.add('text-success');
+      });
+      btn.addEventListener('mouseout', (e) => {
+        const friendName = e.target.dataset.nick;
+        document
+          .querySelector(`[data-add-btn-target="${friendName}"]`)
+          .classList.remove('text-success');
+      });
     });
   }
 


### PR DESCRIPTION
<!-- PR Title은 [FEAT/FIX/STYLE/DOCS 등등] Title 형식으로 맞춰주세요 -->

<!-- PR 개요는 이슈링크로 대체합니다 -->
## ⭐️ 해당 이슈
- #298

<!-- 구현사항, 변경사항 등 자세히 적어주세요 -->
<!-- 화면 변경사항이 있다면 해당 화면 이미지도 추가해주시면 좋아요 -->
## 📜 작업 내용
- 친구 검색 목록이 띄엄띄엄 배치되는 문제가 있어서 flex flex-column 추가했습니다.
- 검색한 아이디가 너무 긴 경우 + 버튼을 침범하는 경우가 있어서 줄바꿈 추가했습니다.
- + 버튼 호버 시 해당 아이디도 색상 바뀌도록 마우스 이벤트 추가했습니다.
<img width="718" alt="스크린샷 2024-06-30 오후 12 09 43" src="https://github.com/Retro-pong/Transcendence/assets/100325940/bda63f85-0be1-47c0-8e02-f4db6569da79">


<!-- 이 부분은 자세히 리뷰해줬으면 하는 부분이 있다면 적어주세요 -->
## 📍 리뷰 요구사항
- 
