### PR TITLE
[Fix] 로컬 게임 뒤로 가기 에러

### DIFF
--- a/frontend/src/pages/game/PlayGame.js
+++ b/frontend/src/pages/game/PlayGame.js
@@ -76,13 +76,13 @@ class PlayGame extends PageComponent {
           </div>
           <div id="gameResult" class="fs-15 w-100 text-center"></div>
           <div id="finalText" class="fs-13 w-100 text-center text-success d-none"></div>
-          <div class="w-75 d-flex justify-content-between align-items-center">
-            <div id="modalRedNick" class="text-danger w-25 fs-12"></div>
-            <div id="redScore" class="text-danger w-25 text-end fs-13"></div>
+          <div class="w-75 row d-flex align-items-center">
+            <div id="modalRedNick" class="text-danger col-10 fs-11 text-break"></div>
+            <div id="redScore" class="text-danger col-2 text-end fs-13"></div>
           </div>          
-          <div class="w-75 d-flex justify-content-between align-items-center">
-            <div id="modalBlueNick" class="text-primary w-25 fs-12"></div>
-            <div id="blueScore" class="text-primary w-25 text-end fs-13"></div>
+          <div class="w-75 row d-flex align-items-center">
+            <div id="modalBlueNick" class="text-primary col-10 fs-11 text-break"></div>
+            <div id="blueScore" class="text-primary col-2 text-end fs-13"></div>
           </div>
         </div>
       `,
@@ -98,8 +98,8 @@ class PlayGame extends PageComponent {
            class="position-absolute top-0 start-50 translate-middle-x px-3 w-40 text-white d-flex flex-column align-items-center border border-5 rounded">
         <span class="fs-6">score</span>
         <div class="d-flex w-100 fs-6">
-          <span id="player1Nick" class="w-50 d-flex justify-content-center text-danger">RED</span>
-          <span id="player2Nick" class="w-50 d-flex justify-content-center text-primary">BLUE</span>
+          <span id="player1Nick" class="w-50 d-flex justify-content-center text-danger text-break">RED</span>
+          <span id="player2Nick" class="w-50 d-flex justify-content-center text-primary text-break">BLUE</span>
         </div>
         <div class="d-flex w-100 fs-8">
           <span id="player1Score" class="w-50 d-flex justify-content-center text-danger" data-score="0">0</span>

--- a/frontend/src/pages/game/PlayGame.js
+++ b/frontend/src/pages/game/PlayGame.js
@@ -58,6 +58,7 @@ class PlayGame extends PageComponent {
   }
 
   setDisposeAll() {
+    this.gameManger.resetLocalTextTimeOut();
     this.gameManger.disposeAll();
     this.gameManger = null;
     SocketManager.gameSocket = null;

--- a/frontend/src/utils/game/GameManager.js
+++ b/frontend/src/utils/game/GameManager.js
@@ -13,8 +13,6 @@ import localGameCustomSetting from '@/utils/game/setting/localGameCustomSetting'
 
 class GameManager {
   constructor() {
-    this.renderRequestId = null;
-
     this.scene = new THREE.Scene();
     this.canvas = document.getElementById('gameCanvas');
     this.renderer = new THREE.WebGLRenderer({
@@ -54,6 +52,7 @@ class GameManager {
     // 로컬 일시정지 위한 변수
     this.localGameRender = this.localGameRender.bind(this);
     this.isRendering = false;
+    this.renderRequestId = null;
 
     this.localGameSpped = 3;
     this.localTextTimeOut = {


### PR DESCRIPTION
<!-- PR Title은 [FEAT/FIX/STYLE/DOCS 등등] Title 형식으로 맞춰주세요 -->

<!-- PR 개요는 이슈링크로 대체합니다 -->
## ⭐️ 해당 이슈
- #301

<!-- 구현사항, 변경사항 등 자세히 적어주세요 -->
<!-- 화면 변경사항이 있다면 해당 화면 이미지도 추가해주시면 좋아요 -->
## 📜 작업 내용
- 게임에서 뒤로 가기 시 라우터에서 setDisposeAll 실행하는데 그 안에 resetLocalTextTimeout 함수 추가했습니다.
- 게임 점수판과 결과 모달에 text-break를 추가하고 너비 수정했습니다.

<!-- 이 부분은 자세히 리뷰해줬으면 하는 부분이 있다면 적어주세요 -->
## 📍 리뷰 요구사항
- 
